### PR TITLE
Fix mismatched vendorId for romac

### DIFF
--- a/src/other/romac/romac.json
+++ b/src/other/romac/romac.json
@@ -1,6 +1,6 @@
 {
   "name": "romac",
-  "vendorId": "0x5253",
+  "vendorId": "0x4b4b",
   "productId": "0x0001",
   "lighting": "none",
   "matrix": {"rows": 4, "cols": 3},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixes the “vendorId” to match the one used in QMK under kingly_keys/romac

## Types of Changes

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Adding a keyboard to VIA
- [x] Changing a keyboard already in VIA
- [x] Bug fix
- [ ] Documentation


## Checklist

<!--- Put an `x` in all the boxes that apply. -->
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] The QMK firmware can be built using QMK master repo.
