### PR TITLE
Add QMK lighting keycodes to KBD MkII RGB

### DIFF
--- a/src/other/kbd67mkii/kbd67mkiirgbv1.json
+++ b/src/other/kbd67mkii/kbd67mkiirgbv1.json
@@ -2,7 +2,10 @@
     "name": "KBD67 MkII RGB V1",
     "vendorId": "0x4B42",
     "productId": "0x1224",
-    "lighting": "none",
+    "lighting": {
+        "extends": "none",
+        "keycodes": "qmk"
+    },
     "matrix": {
       "rows": 5,
       "cols": 15

--- a/src/other/kbd67mkii/kbd67mkiirgbv2.json
+++ b/src/other/kbd67mkii/kbd67mkiirgbv2.json
@@ -2,7 +2,10 @@
     "name": "KBD67 MkII RGB V2",
     "vendorId": "0x4B42",
     "productId": "0x1225",
-    "lighting": "none",
+    "lighting": {
+        "extends": "none",
+        "keycodes": "qmk"
+    },
     "matrix": {
       "rows": 5,
       "cols": 15


### PR DESCRIPTION
## Description

Adding the QMK lighting keycodes for KBD MkII RGB since it supports RGB.

## Types of Changes

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Adding a keyboard to VIA
- [x] Changing a keyboard already in VIA
- [ ] Bug fix
- [ ] Documentation


## Checklist

<!--- Put an `x` in all the boxes that apply. -->
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [X] The QMK firmware can be built using QMK master repo.
