### PR TITLE
Add RGB to Launch Pad

### DIFF
--- a/src/other/launchpad/launchpad.json
+++ b/src/other/launchpad/launchpad.json
@@ -2,7 +2,7 @@
     "name": "Launch Pad",
     "vendorId": "0x1337",
     "productId": "0x6007",
-    "lighting": "none",
+    "lighting": "qmk_rgblight",
     "matrix": {
         "rows": 4,
         "cols": 2


### PR DESCRIPTION
Add RGB support to launchpad

## Checklist

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
