### PR TITLE
Add keebio/bdn9

### DIFF
--- a/src/keebio/bdn9/bdn9.json
+++ b/src/keebio/bdn9/bdn9.json
@@ -1,0 +1,17 @@
+{
+    "name": "BDN9",
+    "vendorId": "0xcb10",
+    "productId": "0x1133",
+    "lighting": "qmk_backlight_rgblight",
+    "matrix": {
+        "rows": 3,
+        "cols": 3
+    },
+    "layouts": {
+        "keymap": [
+            ["0,0", "0,1", "0,2"],
+            ["1,0", "1,1", "1,2"],
+            ["2,0", "2,1", "2,2"]
+        ]
+    }
+}


### PR DESCRIPTION
Add support for keebio/bdn9

## Checklist

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
