### PR TITLE
add rgb backlight via support for niu mini

### DIFF
--- a/src/kbdfans/niu_mini/niu_mini.json
+++ b/src/kbdfans/niu_mini/niu_mini.json
@@ -2,7 +2,7 @@
   "name":"niu_mini",
   "vendorId":"0x6E6D",
   "productId":"0x0001",
-  "lighting":"qmk_backlight",
+  "lighting": "qmk_backlight_rgblight",
   "matrix":{
     "rows":4,
     "cols":12


### PR DESCRIPTION
add rgb backlight via support for niu mini, move to kbdfans folder

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
