### PR TITLE
Update hannah60rgb.json

### DIFF
--- a/src/mechlovin/hannah60rgb/hannah60rgb.json
+++ b/src/mechlovin/hannah60rgb/hannah60rgb.json
@@ -2,7 +2,10 @@
   "name": "Hannah60 RGB",
   "vendorId": "0x4D4C",
   "productId": "0x6001",
-  "lighting": "qmk_rgblight",
+  "lighting": {
+      "extends": "none",
+      "keycodes": "qmk"
+  },
   "matrix": {"rows": 5, "cols": 14},
   "layouts": {
     "labels": [


### PR DESCRIPTION
Refactor lighting function
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

VIA doesn't support ws2812 rgb matrix for now. So i have to remove qmk_rgblight function 
Thanks!
## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
