### PR TITLE
Added Via support to spaceman 2% milk

### DIFF
--- a/src/spaceman/2_milk.json
+++ b/src/spaceman/2_milk.json
@@ -1,0 +1,21 @@
+{
+  "name": "spaceman_2_milk",
+  "vendorId": "0x5350",
+  "productId": "0x3225",
+  "lighting": "qmk_backlight",
+  "matrix": {
+    "rows": 2,
+    "cols": 1
+  },
+  "layouts": {
+    "keymap": [
+      [
+        "0,0"
+      ],
+      [
+        "1,0"
+      ]
+    ]
+    
+  }
+}

--- a/src/spaceman/2_milk.json
+++ b/src/spaceman/2_milk.json
@@ -1,6 +1,6 @@
 {
   "name": "spaceman_2_milk",
-  "vendorId": "0x5350",
+  "vendorId": "0x5342",
   "productId": "0x3225",
   "lighting": "qmk_backlight",
   "matrix": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Created spaceman/2_milk.json 
## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/9484
## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x ] I have tested this keyboard definition using VIA's "Design" tab.
- [x ] I have tested this keyboard definition with firmware on a device.
- [x ] I have assigned alpha keys and modifier keys with the correct colors.
- [x ] The Vendor ID is not `0xFEED`
