### PR TITLE
Add VIA support for mixi

### DIFF
--- a/src/mixi/mixi.json
+++ b/src/mixi/mixi.json
@@ -1,0 +1,18 @@
+{
+    "name": "Mixi",
+    "vendorId": "0x4752",
+    "productId": "0x4d49",
+    "lighting": "qmk_rgblight",
+    "customFeatures": ["rotary-encoder"],
+    "matrix": {
+        "rows": 3,
+        "cols": 3
+    },
+    "layouts": {
+        "keymap": [
+            ["0,0", "0,1", "0,2"],
+            ["1,0", "1,1", "1,2"],
+            ["2,0", "2,1", "2,2"]
+        ]
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Added VIA support for Mixi macropad.
<!--- Describe your changes in detail here. -->

## QMK Pull Request 
initial: https://github.com/qmk/qmk_firmware/pull/9364 (merged)
updates: https://github.com/qmk/qmk_firmware/pull/9467 (merged)
<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
