### PR TITLE
Add support for HHKB Lite 2 Teensy controller

### DIFF
--- a/src/hhkb_lite_2/hhkb_lite_2.json
+++ b/src/hhkb_lite_2/hhkb_lite_2.json
@@ -1,0 +1,49 @@
+{
+    "name": "HHKB Lite 2",
+    "vendorId": "0x88b2",
+    "productId": "0x88b2",
+    "keyboard": "hhkb_lite_2",
+    "lighting": "none",
+    "matrix": { "rows": 8, "cols": 14 },
+    "keymap": "via",
+    "layout": "LAYOUT",
+    "layouts": {
+        "keymap": [
+            [{"y": 1.5, "c": "#777777", "f": 4}, "5,9", {"c": "#cccccc", "f": 5}, "1,9", "1,8", "1,7", "1,6", "0,6", "0,5", "1,5", "1,4", "1,3", "1,2", "0,2", "0,4", "4,13", {"f": 4}, "0,9"],
+            [{"c": "#777777", "w": 1.5}, "3,9", {"c": "#cccccc", "f": 5}, "2,9", "2,8", "2,7", "2,6", "3,6", "3,5", "2,5", "2,4", "2,3", "2,2", "3,2", "3,4", {"c": "#777777", "w": 1.5}, "3,13"],
+            [{"c": "#aaaaaa", "f": 4, "w": 1.75}, "0,10", {"c": "#cccccc", "f": 5}, "4,9", "4,8", "4,7", "4,6", "5,6", "5,5", "4,5", "4,4", "4,3", "4,2", "5,2", {"c": "#777777", "w": 2.25}, "6,13"],
+            [{"c": "#aaaaaa", "f": 4, "w": 2.25}, "3,11", {"c": "#cccccc", "f": 5}, "6,9", "6,8", "6,7", "6,6", "7,6", "7,5", "6,5", "6,0", "6,3", "7,2", {"c": "#aaaaaa", "w": 1.75}, "6,11"],
+            [{"x": 1, "f": 4}, "0,1", "5,12", "4,0", {"c": "#cccccc", "f": 5, "w": 6}, "7,13", {"c": "#aaaaaa", "f": 4}, "3,0", "7,12", {"x": 1, "c": "#777777", "f": 3, "h": 0.75}, "0,0"],
+            [{"y": -0.25, "x": 12, "h": 0.75}, "3,3", {"h": 0.75}, "1,0", {"h": 0.75}, "2,0"]
+        ]
+    },
+    "layers": [
+        [
+            "KC_ESC", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSLS", "KC_GRV",
+            "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P",   "KC_LBRC", "KC_RBRC",    "KC_BSPC",
+            "KC_LCTL",       "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L",     "KC_SCLN", "KC_QUOT",    "KC_ENT",
+            "KC_LSFT",         "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M",    "KC_COMM", "KC_DOT", "KC_SLSH",   "KC_RSFT",
+                    "MO(1)", "KC_LALT", "KC_LGUI",               "KC_SPC",                 "KC_RGUI", "KC_RALT",
+                                                                                                               "KC_UP",
+                                                                                                    "KC_LEFT", "KC_DOWN", "KC_RGHT"
+        ],
+        [
+            "RESET",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",
+            "KC_CAPS",      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",  "KC_NO",        "KC_TRNS",
+            "KC_TRNS",          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RIGHT",         "KC_TRNS",
+            "KC_TRNS",               "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_END", "KC_PGDN", "KC_DOWN",          "KC_TRNS",
+                    "KC_TRNS", "KC_TRNS", "KC_TRNS",                        "KC_TRNS",                   "KC_TRNS", "KC_TRNS",
+                                                                                                                             "KC_PGUP",
+                                                                                                                  "KC_HOME", "KC_PGDN", "KC_END"
+        ],
+        [
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",   "KC_TRNS", "KC_TRNS",    "KC_TRNS",
+            "KC_TRNS",       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",     "KC_TRNS", "KC_TRNS",    "KC_TRNS",
+            "KC_TRNS",         "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS",   "KC_TRNS",
+                                 "KC_TRNS", "KC_TRNS", "KC_TRNS",               "KC_TRNS",                 "KC_TRNS", "KC_TRNS",
+                                                                                                                                           "KC_TRNS",
+                                                                                                                                "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        ]
+    ]
+}


### PR DESCRIPTION
## Description

Support for the replacement board [here](https://github.com/thirteen37/HHKB-Lite-2-Teensy).

## QMK Pull Request 

qmk/qmk_firmware#9188

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
