### PR TITLE
Update sweet16v1.json

### DIFF
--- a/src/1upkeyboards/sweet16/sweet16v1.json
+++ b/src/1upkeyboards/sweet16/sweet16v1.json
@@ -2,7 +2,7 @@
     "name": "sweet16 v1",
     "vendorId": "0x6F75",
     "productId": "0x0161",
-    "lighting": "qmk_backlight",
+    "lighting": "qmk_rgblight",
     "matrix": {
       "rows": 4,
       "cols": 4


### PR DESCRIPTION
sweet16 does not support backlit keys, however it does support rgb underglow on pin B1. this edit enables via to manipulate the leds in the software.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ x] I have tested this keyboard definition using VIA's "Design" tab.
- [ x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
