### PR TITLE
Add via support for binepad/bn003

### DIFF
--- a/src/binepad/bn003/bn003.json
+++ b/src/binepad/bn003/bn003.json
@@ -1,0 +1,15 @@
+{
+    "name": "BN003",
+    "vendorId": "0x4249",
+    "productId": "0x4287",
+    "lighting": "none",
+    "matrix": {
+        "rows": 1,
+        "cols": 3
+    },
+    "layouts": {
+        "keymap": [
+            ["0,0", "0,1", "0,2"]
+        ]
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<Add via support for binepad/bn003> 

## QMK Pull Request 

<https://github.com/qmk/qmk_firmware/pull/10276> (Already merged!)

VIA Keymap:
<https://github.com/qmk/qmk_firmware/tree/master/keyboards/binepad/bn003/keymaps/via>

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
