### PR TITLE
Update XD75 VENDOR_ID

### DIFF
--- a/src/kprepublic/xd75.json
+++ b/src/kprepublic/xd75.json
@@ -1,6 +1,6 @@
 {
   "name": "KPrepublic XD75",
-  "vendorId": "0xCDCD",
+  "vendorId": "0x7844",
   "productId": "0x7575",
   "lighting": "qmk_rgblight",
   "matrix": { "rows": 5, "cols": 15 },


### PR DESCRIPTION
Synchronise `VENDOR_ID` with https://github.com/qmk/qmk_firmware/blob/master/keyboards/xd75/config.h so that VIA works with both firmware provided and that compiled from qmk/qmk_firmware.

Background: Currently, the firmware `xd75_via.hex` at https://caniusevia.com/docs/download_firmware uses `VENDOR_ID` `0x7844` (which is also the same value as that listed in the qmk/qmk_firmware repo). However, it does not work with VIA (tested using https://github.com/the-via/releases/releases/download/v1.3.1/via-1.3.1-linux.AppImage) which expects `VENDOR_ID` `0xCDCD`.