### PR TITLE
Add geekboards macropad_v2

### DIFF
--- a/src/geekboards/macropad_v2/macropad_v2.json
+++ b/src/geekboards/macropad_v2/macropad_v2.json
@@ -1,0 +1,47 @@
+{
+  "name": "Geekboards Macropad v2",
+  "vendorId": "0x0483",
+  "productId": "0xA372",
+  "customKeycodes": [
+    {"name": "Super Alt Tab", "title": "Super Alt Tab", "shortName": "AltTab"}
+  ],
+  "lighting": {
+    "extends":"qmk_rgblight",
+    "underglowEffects": [
+      ["None", 0],
+      ["SOLID_COLOR", 1],
+      ["GRADIENT_UP_DOWN", 1],
+      ["GRADIENT_LEFT_RIGHT", 1],
+      ["BREATHING", 1],
+      ["BAND_VAL", 1],
+      ["CYCLE_ALL", 1],
+      ["CYCLE_LEFT_RIGHT", 1],
+      ["CYCLE_UP_DOWN", 1],
+      ["CYCLE_OUT_IN_DUAL", 1],
+      ["CYCLE_PINWHEEL", 1],
+      ["DUAL_BEACON", 1],
+      ["TYPING_HEATMAP", 1],
+      ["SOLID_REACTIVE", 1],
+      ["SOLID_REACTIVE_WIDE", 1],
+      ["SOLID_REACTIVE_MULTIWIDE", 1],
+      ["SOLID_REACTIVE_NEXUS", 1],
+      ["SOLID_REACTIVE_MULTINEXUS", 1],
+      ["SPLASH", 1],
+      ["MULTISPLASH", 1],
+      ["SOLID_SPLASH", 1],
+      ["SOLID_MULTISPLASH", 1]
+    ],
+    "supportedLightingValues": [
+      128,
+      129,
+      131
+    ]
+  },
+  "matrix": { "rows": 2, "cols": 4 },
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2", "0,3"],
+      ["1,0", "1,1", "1,2", "1,3"]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Via configs for Geekboards Macropad V2, 8-keys macropad with RGB lighting
<!--- Describe your changes in detail here. -->

## QMK Pull Request 
https://github.com/qmk/qmk_firmware/pull/11045
<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
