### PR TITLE
added layout for [1x4] + 1 macropad

### DIFF
--- a/src/arrayperipherals/1x4p1/1x4p1.json
+++ b/src/arrayperipherals/1x4p1/1x4p1.json
@@ -1,0 +1,13 @@
+{
+  "name": "[1 x 4] + 1 Macropad",
+  "vendorId": "0x4152",
+  "productId": "0x4F46",
+  "lighting": "none",
+  "matrix": { "rows": 1, "cols": 5 },
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2", "0,3", {"x":0.5,"c":"#777777"},"0,4"]
+    ]
+  }
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Initial commit for VIA compatibility for the [1x4]+1 Macropad.

## QMK Pull Request 

qmk/qmk_firmware/pull/11186

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
