### PR TITLE
Update PloopyCo devices to add better VIA support

### DIFF
--- a/src/ploopyco/mouse/mouse.json
+++ b/src/ploopyco/mouse/mouse.json
@@ -3,6 +3,10 @@
     "vendorId": "0x5043",
     "productId": "0x4D6F",
     "lighting": "none",
+    "customKeycodes": [
+        {"name": "DPI Config", "title": "DPI Config: Cycles through the DPI settings", "shortName": "DPI"},
+        {"name": "Drag Scroll", "title": "Drag Scroll: Enables you to scroll instead of moving the cursor", "shortName": "DragScl"}
+    ],
     "matrix": { "rows": 1, "cols": 8 },
     "layouts": {
         "keymap": [

--- a/src/ploopyco/trackball/trackball.json
+++ b/src/ploopyco/trackball/trackball.json
@@ -1,39 +1,43 @@
 {
-  "name": "PloopyCo Trackball",
-  "vendorId": "0x5043",
-  "productId": "0x5442",
-  "lighting": "none",
-  "matrix": { "rows": 1, "cols": 6 },
-  "layouts": {
-    "keymap": [
-      [
-        {
-          "h": 2
-        },
-        "0,0",
-        {
-          "x": 1,
-          "h": 2
-        },
-        "0,2",
-        {
-          "x": 0.5,
-          "h": 2
-        },
-        "0,3",
-        {
-          "h": 2
-        },
-        "0,4"
-      ],
-      [
-        {
-          "y": -0.75,
-          "x": 1,
-          "h": 1.5
-        },
-        "0,1"
-      ]
-    ]
-  }
+    "name": "PloopyCo Trackball",
+    "vendorId": "0x5043",
+    "productId": "0x5442",
+    "lighting": "none",
+    "customKeycodes": [
+        {"name": "DPI Config", "title": "DPI Config", "shortName": "DPI"},
+        {"name": "Drag Scroll", "title": "Drag Scroll", "shortName": "DragScl"}
+    ],
+    "matrix": { "rows": 1, "cols": 6 },
+    "layouts": {
+        "keymap": [
+            [
+                {
+                "h": 2
+                },
+                "0,0",
+                {
+                "x": 1,
+                "h": 2
+                },
+                "0,2",
+                {
+                "x": 0.5,
+                "h": 2
+                },
+                "0,3",
+                {
+                "h": 2
+                },
+                "0,4"
+            ],
+            [
+                {
+                "y": -0.75,
+                "x": 1,
+                "h": 1.5
+                },
+                "0,1"
+            ]
+        ]
+    }
 }


### PR DESCRIPTION
## Description

Add custom via keycodes for both PloopyCo devices. 

## QMK Pull Request 

Already added, but update PR: https://github.com/qmk/qmk_firmware/pull/11290

## Checklist

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
