### PR TITLE
Fix lighting definition for bdn9rev2.json since it uses RGB Matrix

### DIFF
--- a/src/keebio/bdn9/bdn9rev2.json
+++ b/src/keebio/bdn9/bdn9rev2.json
@@ -2,7 +2,7 @@
     "name": "BDN9",
     "vendorId": "0xcb10",
     "productId": "0x2133",
-    "lighting": "qmk_backlight_rgblight",
+    "lighting": "none",
     "matrix": {
         "rows": 3,
         "cols": 3


### PR DESCRIPTION
Missed a small bug, the Rev2 uses an RGB Matrix implementation which is not supported in VIA yet. So it will cause VIA to lock up if accessing the Lighting section. This sets it to "none" so VIA does not crash.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
