### PR TITLE
Fix The Mark 65 Keymap to allow RGB Configuration in VIA

### DIFF
--- a/src/boardsource/the_mark_65/the_mark_65.json
+++ b/src/boardsource/the_mark_65/the_mark_65.json
@@ -2,7 +2,7 @@
   "name": "The Mark: 65",
   "vendorId": "0x4273",
   "productId": "0x0001",
-  "lighting": "qmk_backlight",
+  "lighting": "qmk_rgblight",
   "matrix": {
     "rows": 5,
     "cols": 16


### PR DESCRIPTION
The Mark 65 Supports QMKs RGB Lightning, it doesn't have backlighting.  This just fixes the layout file.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x ] The Vendor ID is not `0xFEED`
