### PR TITLE
Corrected Layout Labels

### DIFF
--- a/src/Moesode/Bliss/e88.json
+++ b/src/Moesode/Bliss/e88.json
@@ -9,7 +9,7 @@
       "ISO Enter",
       "Split Left Shift",
       "Split Right Shift",
-      ["Bottom Row","WKL", "ANSI","Tsangan"]
+      ["Bottom Row","WKL","Tsangan", "ANSI"]
   ],
       "keymap": [
 


### PR DESCRIPTION
Corrected the layout names.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Simple fix as the layout names were swapped for Tsangan and ANSI

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [ X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ X] I have tested this keyboard definition using VIA's "Design" tab.
- [ X] I have tested this keyboard definition with firmware on a device.
- [ X] I have assigned alpha keys and modifier keys with the correct colors.
- [ X] The Vendor ID is not `0xFEED`
