### PR TITLE
Fix noxary Product IDs

### DIFF
--- a/src/noxary/220/noxary_220.json
+++ b/src/noxary/220/noxary_220.json
@@ -1,7 +1,7 @@
 {
   "name": "Noxary 220",
   "vendorId": "0x4e58",
-  "productId": "0x00DC",
+  "productId": "0x0899",
   "lighting": "qmk_backlight",
   "matrix": {"rows": 6, "cols": 4},
   "layouts": {

--- a/src/noxary/260/noxary_260.json
+++ b/src/noxary/260/noxary_260.json
@@ -1,7 +1,7 @@
 {
     "name": "Noxary 260",
     "vendorId": "0x4e58",
-    "productId": "0x0104",
+    "productId": "0x0A29",
     "lighting": "qmk_backlight",
     "matrix": {"rows": 5, "cols": 15},
     "layouts": {

--- a/src/noxary/260/noxary_260.json
+++ b/src/noxary/260/noxary_260.json
@@ -1,7 +1,7 @@
 {
     "name": "Noxary 260",
     "vendorId": "0x4e58",
-    "productId": "0x003C",
+    "productId": "0x0104",
     "lighting": "qmk_backlight",
     "matrix": {"rows": 5, "cols": 15},
     "layouts": {

--- a/src/noxary/268/noxary_268.json
+++ b/src/noxary/268/noxary_268.json
@@ -1,7 +1,7 @@
 {
   "name": "Noxary 268",
   "vendorId": "0x4e58",
-  "productId": "0x010C",
+  "productId": "0x0A79",
   "lighting": "qmk_backlight",
   "matrix": {"rows": 5,"cols": 16},
   "layouts": {

--- a/src/noxary/268_2/noxary_268_2.json
+++ b/src/noxary/268_2/noxary_268_2.json
@@ -1,7 +1,7 @@
 {
   "name": "Noxary 268.2",
   "vendorId": "0x4e58",
-  "productId": "0x010C",
+  "productId": "0x0A7A",
   "lighting": "qmk_backlight",
   "matrix": {
     "rows": 5,

--- a/src/noxary/280/noxary_280.json
+++ b/src/noxary/280/noxary_280.json
@@ -1,7 +1,7 @@
 {
   "name": "Noxary 280",
   "vendorId": "0x4e58",
-  "productId": "0x0118",
+  "productId": "0x0AF1",
   "lighting": "qmk_backlight",
   "matrix": {"rows": 12, "cols": 9},
   "layouts": {

--- a/src/noxary/x268/noxary_x268.json
+++ b/src/noxary/x268/noxary_x268.json
@@ -1,7 +1,7 @@
 {
   "name": "Noxary x268",
   "vendorId": "0x4e58",
-  "productId": "0x010C",
+  "productId": "0x0A7B",
   "lighting": "qmk_backlight",
   "matrix": {"rows": 5,"cols": 16},
   "layouts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Changed the product ID of noxary boards so that different revisions can have different IDs, previously used Device_Ver. This was changed so VIA can differenciate the boards correctly.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/11771/

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
