### PR TITLE
Change productId of YMDK/bface board to be equal one in QMK

### DIFF
--- a/src/YMDK/bface/bface.json
+++ b/src/YMDK/bface/bface.json
@@ -1,7 +1,7 @@
 {
   "name": "YMDK Bface",
   "vendorId": "0x20A0",
-  "productId": "0x422D",
+  "productId": "0x4266",
   "lighting": "qmk_backlight_rgblight",
   "matrix": {
     "rows":5,

--- a/src/YMDK/bface/bface.json
+++ b/src/YMDK/bface/bface.json
@@ -1,6 +1,6 @@
 {
   "name": "YMDK Bface",
-  "vendorId": "0x20A0",
+  "vendorId": "0x594D",
   "productId": "0x4266",
   "lighting": "qmk_backlight_rgblight",
   "matrix": {


### PR DESCRIPTION
https://github.com/qmk/qmk_firmware/blob/master/keyboards/ymdk/bface/config.h

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

YMDK bface board have different product id in QMK and VIA. VIA id is used by YMD75 in QMK.

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
