### PR TITLE
added split space bar support for yd60qm

### DIFF
--- a/src/YMDK/yd60mq/yd60mq.json
+++ b/src/YMDK/yd60mq/yd60mq.json
@@ -462,14 +462,61 @@
         "4,11\n\n\n4,4",
         "4,12\n\n\n4,4",
         "4,13\n\n\n4,4"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 24.75,
+          "w": 1.25
+        },
+        "4,0\n\n\n4,5",
+        {
+          "w": 1.25
+        },
+        "4,1\n\n\n4,5",
+        {
+          "w": 1.25
+        },
+        "4,2\n\n\n4,5",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3\n\n\n4,5",
+        {
+          "w": 1.25
+        },
+        "4,7\n\n\n4,5",
+        {
+          "w": 2.75
+        },
+        "4,5\n\n\n4,5",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,6\n\n\n4,5",
+        {
+          "w": 1.25
+        },
+        "4,9\n\n\n4,4",
+        {
+          "w": 1.25
+        },
+        "4,11\n\n\n4,5",
+        {
+          "w": 1.25
+        },
+        "4,12\n\n\n4,5"
       ]
+
     ],
 "labels": [
   "Split Backspace",
   "Stepped Caps Lock",
   "ISO Enter",
   ["ZXC ROW / R4", "ANSI Standard", "ANSI Split Right Shift", "ANSI Big Question Mark Arrow Keys", "ISO Standart", "ISO Split Right Shift", "ISO Big Question Mark Arrow Keys", "2u Left Shift Arrow keys"],
-  ["Bottom Row", "ANSI", "Tsangan", "HHKB", "Arrow Keys", "Japanese"]
+  ["Bottom Row", "ANSI", "Tsangan", "HHKB", "Arrow Keys", "Japanese", "Split Spacebar"]
 ]
 }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
