### PR TITLE
add rgb underglow to h60

### DIFF
--- a/src/hineybush/h60/h60.json
+++ b/src/hineybush/h60/h60.json
@@ -2,9 +2,7 @@
   "name": "h60",
   "vendorId": "0x04D8",
   "productId": "0xEBBE",
-  "lighting": {
-    "extends": "none"
-  },
+  "lighting": "qmk_backlight_rgblight",
   "matrix": {
     "rows": 5,
     "cols": 14


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add RGB underglow definition to h60.

## QMK Pull Request 

N/A, RGB already added in QMK

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
