### PR TITLE
Added Superhuman SHK9 macro board

### DIFF
--- a/src/superhuman/shk9.json
+++ b/src/superhuman/shk9.json
@@ -1,0 +1,17 @@
+{
+    "name": "Superhuman SHK9",
+    "vendorId": "0x5348",
+    "productId": "0x4B39",
+    "lighting": "none",
+    "matrix": { 
+        "rows": 3,
+        "cols": 3 
+    },
+    "layouts": {
+      "keymap": [
+        ["0,0", "0,1", "0,2"],
+        ["1,0", "1,1", "1,2"],
+        ["2,0", "2,1", "2,2"]
+      ]
+    }
+  }


### PR DESCRIPTION
Added Superhuman SHK9 macropad definition.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The SHK9 is a tiny 3x3 macropad! Fully configurable with via.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/11505

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
