### PR TITLE
added 0xCB 1337 keyboard

### DIFF
--- a/src/0xcb/1337/1337.json
+++ b/src/0xcb/1337/1337.json
@@ -1,0 +1,14 @@
+{
+  "name": "0xCB 1337",
+  "vendorId": "0xCB00",
+  "productId": "0x1337",
+  "lighting": "qmk_backlight_rgblight",
+  "matrix": { "rows": 3, "cols": 3 },
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2"],
+      ["1,0", "1,1", "1,2"],
+      ["2,0", "2,1", "2,2"]
+    ]
+  }
+}


### PR DESCRIPTION
Signed-off-by: Conor Burns <mail@conor-burns.com>

Added the 1337 macro pad
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Waiting on merge but via support is enabled by default :)

- support for lighting (RGB and backlight)
<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/12089
## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
