### PR TITLE
fixed typo

### DIFF
--- a/src/4pplet/steezy60_rev_a.json
+++ b/src/4pplet/steezy60_rev_a.json
@@ -9,7 +9,7 @@
       "Split Backspace",
       "ISO Enter",
       "Split Right Shift",
-      "Slit Left Shift",
+      "Split Left Shift",
       ["Bottom Row", "Standard","Tsangan/AEK","Full Mods", "Split std","Split Tsangan/AEK"]
     ],
         "keymap": 


### PR DESCRIPTION
## Description

Fixed a typo in tab. Missing "p" in "Split"

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The QMK source code follows the guide here: https://caniusevia.com/docs/configuring_qmk
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
