### PR TITLE
GodSpeed75: add RGB support

### DIFF
--- a/src/tkc/godspeed75/godspeed75.json
+++ b/src/tkc/godspeed75/godspeed75.json
@@ -2,7 +2,7 @@
   "name": "GodSpeed75",
   "vendorId": "0x544B",
   "productId": "0x0006",
-  "lighting": "none",
+  "lighting": "qmk_rgblight",
   "matrix": {"rows": 12, "cols": 8},
   "layouts": {
     "labels": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/12278 - adding support for RGB

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
