### PR TITLE
Add VIA support for Rubi

### DIFF
--- a/src/rubi/rubi.json
+++ b/src/rubi/rubi.json
@@ -1,0 +1,95 @@
+{
+   "name": "Rubi",
+   "vendorId": "0x4752",
+   "productId": "0x5242",
+   "lighting": "none",
+   "customFeatures": [
+      "rotary-encoder"
+   ],
+   "customKeycodes": [
+      {
+         "name": "Encoder Press",
+         "title": "Encoder Press",
+         "shortName": "EncPrs"
+      },
+      {
+         "name": "Calculator Plus",
+         "title": "Calc Plus",
+         "shortName": "ClPlus"
+      },
+      {
+         "name": "Calculator Star",
+         "title": "Calc Star",
+         "shortName": "ClStar"
+      },
+      {
+         "name": "Calculator Type",
+         "title": "Calc Type",
+         "shortName": "ClType"
+      }
+   ],
+   "matrix": {
+      "rows": 5,
+      "cols": 4
+   },
+   "layouts": {
+      "keymap": [
+         [
+            {
+               "x": 3,
+               "c": "#777777"
+            },
+            "2,3"
+         ],
+         [
+            {
+               "y": 0.25,
+               "c": "#aaaaaa"
+            },
+            "0,0",
+            "0,1",
+            "0,2",
+            "0,3"
+         ],
+         [
+            {
+               "c": "#cccccc"
+            },
+            "1,0",
+            "1,1",
+            "1,2",
+            {
+               "c": "#aaaaaa",
+               "h": 2
+            },
+            "1,3"
+         ],
+         [
+            {
+               "c": "#cccccc"
+            },
+            "2,0",
+            "2,1",
+            "2,2"
+         ],
+         [
+            "3,0",
+            "3,1",
+            "3,2",
+            {
+               "c": "#777777",
+               "h": 2
+            },
+            "3,3"
+         ],
+         [
+            {
+               "c": "#cccccc",
+               "w": 2
+            },
+            "4,1",
+            "4,2"
+         ]
+      ]
+   }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add VIA support for Rubi numpad.

## QMK Pull Request 

[Add Rubi Numpad #12283](https://github.com/qmk/qmk_firmware/pull/12283)

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
