### PR TITLE
add cybergear macro25

### DIFF
--- a/src/cybergear/macro25/mkmacro01.json
+++ b/src/cybergear/macro25/mkmacro01.json
@@ -1,0 +1,16 @@
+{
+  "name": "CyberGear Macro25",
+  "vendorId": "1209",
+  "productId": "69A1",
+  "lighting": "none",
+  "matrix": {
+    "rows": 2,
+    "cols": 5
+  },
+  "layouts": {
+    "keymap": [
+      [ "0,0", "0,1", "0,2", "0,3", "0,4" ],
+      [ "1,0", "1,1", "1,2", "1,3", "1,4" ]
+    ]
+  }
+}


### PR DESCRIPTION
Add keyboard support for cybergear macro25

This is macro keyboard to add your own functionality

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/12518

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
