### PR TITLE
GHS.RAR: Fix typo in JSON files

### DIFF
--- a/src/ghs/rar.json
+++ b/src/ghs/rar.json
@@ -219,7 +219,7 @@
         {
           "w": 1.25
         },
-        "10,0\n\n\n3,0",
+        "10,1\n\n\n3,0",
         {
           "c": "#cccccc",
           "w": 6.25
@@ -256,7 +256,7 @@
         {
           "w": 1.5
         },
-        "10,0\n\n\n3,1",
+        "11,0\n\n\n3,1",
         {
           "c": "#cccccc",
           "w": 7
@@ -275,12 +275,14 @@
       "ISO Enter",
       "Split Left Shift",
       [
-        "Standard Bottom Row",
-        "Winkeyless"
+      	"Bottom Row",
+        "Standard",
+        "WKL"
       ],
       [
-        "2x 1.5u Mods",
-        "3x 1u Mods"
+      	"Right Mods",
+        "2x1.5",
+        "3x1"
       ]
     ]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix typo in the JSON file from a previously merged keyboard: https://github.com/the-via/keyboards/pull/202

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/9671

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
