### PR TITLE
Bugfix: Removing backlight-option for keebs where only rgblight is used.

### DIFF
--- a/src/4pplet/aekiso60_rev_a.json
+++ b/src/4pplet/aekiso60_rev_a.json
@@ -2,7 +2,7 @@
     "name": "AEKISO60 Rev A", 
     "vendorId": "0x4444",
     "productId": "0x0001",
-    "lighting": "qmk_backlight_rgblight",
+    "lighting": "qmk_rgblight",
     "matrix": {"rows": 5, "cols": 14},
     "layouts": {
            "labels": [

--- a/src/4pplet/steezy60_rev_a.json
+++ b/src/4pplet/steezy60_rev_a.json
@@ -2,7 +2,7 @@
     "name": "Steezy60 Rev A", 
     "vendorId": "0x4444",
     "productId": "0x0002",
-    "lighting": "qmk_backlight_rgblight",
+    "lighting": "qmk_rgblight",
     "matrix": {"rows": 5, "cols": 14},
     "layouts": {
            "labels": [

--- a/src/4pplet/waffling60_rev_b.json
+++ b/src/4pplet/waffling60_rev_b.json
@@ -2,7 +2,7 @@
     "name": "waffling60 Rev B", 
     "vendorId": "0x4444",
     "productId": "0x0005",
-    "lighting": "qmk_backlight_rgblight",
+    "lighting": "qmk_rgblight",
     "matrix": {"rows": 5, "cols": 14},
     "layouts": {
            "labels": [


### PR DESCRIPTION
Bugfix: Removing backlight-option for keebs where only rgblight is used. 

## Description

There is no backlight driver used, only rgblight for underglow for the affected keebs in this PR.

## Checklist

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
