### PR TITLE
Added twelvekey macropad

### DIFF
--- a/src/kb_elmo/twelvekey/twelvekey.json
+++ b/src/kb_elmo/twelvekey/twelvekey.json
@@ -1,0 +1,33 @@
+{
+    "name":"Twelvekey",
+    "vendorId":"0xA68C",
+    "productId":"0x9879",
+    "lighting": "qmk_backlight",
+    "matrix":{
+       "rows":3,
+       "cols":4
+    },
+    "layouts":{
+       "keymap":[
+          [
+            "0,0",
+            "0,1",
+            "0,2",
+            "0,3"
+          ],
+          [
+            "1,0",
+            "1,1",
+            "1,2",
+            "1,3"
+          ],
+          [
+            "2,0",
+            "2,1",
+            "2,2",
+            "2,3"
+          ]
+        ]
+    }
+ }
+ 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added the Twelvekey macropad

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/12281

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
