### PR TITLE
Enable RGB controls on Noxary 268.2

### DIFF
--- a/src/noxary/268_2_RGB/noxary_268_2_RGB.json
+++ b/src/noxary/268_2_RGB/noxary_268_2_RGB.json
@@ -2,7 +2,7 @@
     "name": "Noxary 268.2 RGB",
     "vendorId": "0x4e58",
     "productId": "0x0A7C",
-    "lighting": "qmk_backlight",
+    "lighting": "qmk_rgblight",
     "matrix": {
       "rows": 5,
       "cols": 16


### PR DESCRIPTION
Looks like @Rozakiin set the wrong lighting mode, the PCB supports RGB lighting so this should allow full controls.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
