### PR TITLE
Minivan : add support for controlling RGB in VIA

### DIFF
--- a/src/thevankeyboards/minivan.json
+++ b/src/thevankeyboards/minivan.json
@@ -2,9 +2,7 @@
   "name": "Minivan",
   "vendorId": "0xFEAE",
   "productId": "0x8844",
-  "lighting": {
-    "extends": "none"
-  },
+  "lighting": "qmk_rgblight",
   "matrix": {
     "rows": 4,
     "cols": 12


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/13157

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
