### PR TITLE
 cannonkeys/devastatingtkl: firmware does include lighting support

### DIFF
--- a/src/cannonkeys/devastatingtkl/devastatingtkl.json
+++ b/src/cannonkeys/devastatingtkl/devastatingtkl.json
@@ -2,7 +2,7 @@
   "name": "DevastatingTKL",
   "vendorId": "0xca04",
   "productId": "0xDE57",
-  "lighting": "none",
+  "lighting": "qmk_backlight",
   "matrix": {"rows": 6, "cols": 18},
   "layouts": {
     "labels": [


### PR DESCRIPTION
## Description

The devastatingtkl firmware does include lighting support, https://github.com/qmk/qmk_firmware/blob/master/keyboards/cannonkeys/devastatingtkl/rules.mk#L21

This modifies the via layout json to show the lighting menu and lighting keys in the UI.

## QMK Pull Request 

_n/a_

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
