### PR TITLE
PORTICO: add support for wt_rgb_backlight

### DIFF
--- a/src/tkc/portico/portico.json
+++ b/src/tkc/portico/portico.json
@@ -2,7 +2,7 @@
   "name": "Portico",
   "vendorId": "0x544B",
   "productId": "0x0008",
-  "lighting": "none",
+  "lighting": "wt_rgb_backlight",
   "matrix": {"rows": 5, "cols": 15},
   "layouts": {
     "keymap":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/13241

<!--- Add link to QMK Pull Request here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
