### PR TITLE
Add Ploopy Trackball Mini

### DIFF
--- a/src/ploopyco/trackball/trackball_mini.json
+++ b/src/ploopyco/trackball/trackball_mini.json
@@ -1,0 +1,43 @@
+{
+    "name": "PloopyCo Trackball Mini",
+    "vendorId": "0x5043",
+    "productId": "0x1EAB",
+    "lighting": "none",
+    "customKeycodes": [
+        {"name": "DPI Config", "title": "DPI Config", "shortName": "DPI"},
+        {"name": "Drag Scroll", "title": "Drag Scroll", "shortName": "DragScl"}
+    ],
+    "matrix": { "rows": 1, "cols": 6 },
+    "layouts": {
+        "keymap": [
+            [
+                {
+                "h": 2
+                },
+                "0,0",
+                {
+                "x": 1,
+                "h": 2
+                },
+                "0,2",
+                {
+                "x": 0.5,
+                "h": 2
+                },
+                "0,3",
+                {
+                "h": 2
+                },
+                "0,4"
+            ],
+            [
+                {
+                "y": -0.75,
+                "x": 1,
+                "h": 1.5
+                },
+                "0,1"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
## Description

Add support for the Ploopy Trackball Mini

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/11994

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already (MANDATORY)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
