### PR TITLE
Fix `0xFEED` Vendor IDs

### DIFF
--- a/src/handwired/3dp660/3dp660.json
+++ b/src/handwired/3dp660/3dp660.json
@@ -1,7 +1,7 @@
 {
     "name": "3dp660",
-    "vendorId": "0xFEED",
-    "productId": "0x6075",
+    "vendorId": "0x676F",
+    "productId": "0x3660",
     "lighting": "none",
     "matrix": {
         "rows": 5,

--- a/src/poker87c/poker87c.json
+++ b/src/poker87c/poker87c.json
@@ -1,7 +1,7 @@
 	{
 	"name" : "POKER-87C",
-	"vendorId" : "0xFEED",
-	"productId" : "0x6060",
+	"vendorId" : "0x6D66",
+	"productId" : "0x087C",
 	"lighting" : {
 		"extends" : "qmk_rgblight"
 	},

--- a/src/poker87d/poker87d.json
+++ b/src/poker87d/poker87d.json
@@ -1,7 +1,7 @@
 	{
 	"name" : "POKER-87D",
-	"vendorId" : "0xFEED",
-	"productId" : "0x6060",
+	"vendorId" : "0x6D66",
+	"productId" : "0x087D",
 	"lighting" : {
 		"extends" : "qmk_rgblight"
 	},

--- a/src/rpiguy9907/Southpaw66/Southpaw66.json
+++ b/src/rpiguy9907/Southpaw66/Southpaw66.json
@@ -1,7 +1,7 @@
 {
     "name": "Southpaw66",
-    "vendorId": "0xFEED",
-    "productId": "0x6077",
+    "vendorId": "0x9907",
+    "productId": "0x5366",
     "lighting": "none",
     "matrix": {
         "rows": 7,

--- a/src/yatara/drink_me/drink_me.json
+++ b/src/yatara/drink_me/drink_me.json
@@ -1,6 +1,6 @@
 {
   "name": "Drink Me",
-  "vendorId": "0xFEED",
+  "vendorId": "0x5961",
   "productId": "0x1470",
   "matrix": {
     "rows": 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A user recently came on to QMK Discord with a BM40HS RGB that was showing up in VIA as a Poker 87D. It was theorized and basically confirmed that the vendor-flashed firmware uses `0xFEED`/`0x6060` as the Vendor/Product ID pairing, and a reflash of firmware from VIA's website fixed the user's issue.

That discovery led to one of the QMK members discovering some keyboards that used `0xFEED` as the Vendor ID, in violation of VIA's own policies.

This PR updates the `vendorId` and `productId` strings of the offending keyboards with updated non-`0xFEED` strings.

## QMK Pull Request

This PR depends on **both** of the following PRs:

- https://github.com/qmk/qmk_firmware/pull/13961
- https://github.com/qmk/qmk_firmware/pull/13962

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
  - As best as I am able, as I don't own any of the devices in question.
- [ ] I have tested this keyboard definition with firmware on a device.
  - No, because I don't own any of the devices in question.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
  - [ ] Seems to have not been done on the original submissions, but I can fix it if desired.
- [x] The Vendor ID is not `0xFEED`
  - *Actually yes.*
