### PR TITLE
Add Stream Cheap 2x4

### DIFF
--- a/src/handwired/streamcheap/2x4/streamcheap2x4.json
+++ b/src/handwired/streamcheap/2x4/streamcheap2x4.json
@@ -1,0 +1,14 @@
+{
+    "name": "Stream Cheap 2x4",
+    "vendorId": "0x7363",
+    "productId": "0x1214",
+    "lighting": "none",
+    "matrix": { "rows": 2, "cols": 4 },
+    "layouts": {
+      "labels": [],
+      "keymap": [
+            ["0,0","0,1","0,2","0,3"],
+            ["1,0","1,1","1,2","1,3"]
+      ]
+    }
+  }


### PR DESCRIPTION
## Description

Add the Stream Cheap - a handwired 2x4 macro pad

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/14001

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
