### PR TITLE
:bug: Fixed productID to not conflict with Discipline

### DIFF
--- a/src/basketweave/basketweave.json
+++ b/src/basketweave/basketweave.json
@@ -1,7 +1,7 @@
 {
   "name": "Basketweave",
   "vendorId": "0x6B62",
-  "productId": "0x6869",
+  "productId": "0x8989",
   "lighting": "none",
   "matrix": {
     "rows": 5,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I fixed a conflict with the productId.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/13972#event-5157130999
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
