### PR TITLE
Update names for Work Louder

### DIFF
--- a/src/work_louder/loop.json
+++ b/src/work_louder/loop.json
@@ -1,5 +1,5 @@
 {
-    "name": "Work Louder Loop Pad",
+    "name": "Loop Pad",
     "vendorId": "0x574C",
     "productId": "0x1DF8",
     "lighting": "qmk_rgblight",

--- a/src/work_louder/nano.json
+++ b/src/work_louder/nano.json
@@ -1,5 +1,5 @@
 {
-    "name": "Work Louder Nano Pad",
+    "name": "Nano Pad",
     "vendorId": "0x574C",
     "productId": "0xE6EF",
     "lighting": "qmk_rgblight",

--- a/src/work_louder/work_board.json
+++ b/src/work_louder/work_board.json
@@ -1,5 +1,5 @@
 {
-    "name": "Work Louder Work Board",
+    "name": "Work Board",
     "vendorId": "0x574C",
     "productId": "0xDCD0",
     "lighting": "qmk_rgblight",


### PR DESCRIPTION
## Description

Update the names for the work louder boards.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/12756

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
