### PR TITLE
Add support for lazydesigners/cassette8 

### DIFF
--- a/src/lazydesigners/cassette8.json
+++ b/src/lazydesigners/cassette8.json
@@ -1,0 +1,13 @@
+{
+  "name": "Cassette8",
+  "vendorId": "0x4C44",
+  "productId": "0x0008",
+  "lighting":  "qmk_rgblight",
+  "matrix": {"rows": 2, "cols": 4},
+"layouts": {
+"keymap":  [
+  ["0,0","0,1","0,2","0,3"],
+  ["1,0","1,1","1,2","1,3"]
+]
+}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Add support for lazydesigners/cassette8 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add support for lazydesigners/cassette8 

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

QMK PR has been merged.
https://github.com/qmk/qmk_firmware/pull/14145

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
