### PR TITLE
Keebio Sinc: Add blocker right-mods layout option

### DIFF
--- a/src/keebio/sinc/sinc-rev2.json
+++ b/src/keebio/sinc/sinc-rev2.json
@@ -13,7 +13,7 @@
       "Left Macropad",
       ["Right Shift", "Standard", "1.75u Shift", "1.75u /"],
       ["Right Space", "Standard", "Fn-Space"],
-      ["Right Mods", "4x 1.25u", "5x 1u"],
+      ["Right Mods", "4x 1.25u", "5x 1u", "Blocker"],
       ["Left Space", "1.25-2.25", "2.25-1.25", "1.25-1-1.25"]
     ],
     "keymap": [
@@ -244,7 +244,15 @@
         "4,5\n\n\n8,2",
         "4,6\n\n\n8,2",
         {"w": 1.25},
-        "4,7\n\n\n8,2"
+        "4,7\n\n\n8,2",
+        {"x": 3.75, "w": 1.25},
+        "10,2\n\n\n7,2",
+        {"w": 1.25},
+        "10,3\n\n\n7,2",
+        {"w": 0.5, "d": true},
+        "10,4\n\n\n7,2",
+        "10,6\n\n\n7,2",
+        "10,7\n\n\n7,2"
       ]
     ]
   }

--- a/v3/keebio/sinc/sinc-rev2.json
+++ b/v3/keebio/sinc/sinc-rev2.json
@@ -22,7 +22,7 @@
       "Left Macropad",
       ["Right Shift", "Standard", "1.75u Shift", "1.75u /"],
       ["Right Space", "Standard", "Fn-Space"],
-      ["Right Mods", "4x 1.25u", "5x 1u"],
+      ["Right Mods", "4x 1.25u", "5x 1u", "Blocker"],
       ["Left Space", "1.25-2.25", "2.25-1.25", "1.25-1-1.25"]
     ],
     "keymap": [
@@ -253,7 +253,15 @@
         "4,5\n\n\n8,2",
         "4,6\n\n\n8,2",
         {"w": 1.25},
-        "4,7\n\n\n8,2"
+        "4,7\n\n\n8,2",
+        {"x": 3.75, "w": 1.25},
+        "10,2\n\n\n7,2",
+        {"w": 1.25},
+        "10,3\n\n\n7,2",
+        {"w": 0.5, "d": true},
+        "10,4\n\n\n7,2",
+        "10,6\n\n\n7,2",
+        "10,7\n\n\n7,2"
       ]
     ]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This is a supported version of the Keebio Sinc, and offered as a [pre-built](https://keeb.io/collections/sinc/products/sinc-keyboard-pre-built) variation.

![keyboard-layout](https://user-images.githubusercontent.com/263461/143722705-56a967da-e47c-4884-b457-e42c2bf142c4.png)

<img width="518" alt="Screen Shot 2021-11-27 at 3 04 54 PM" src="https://user-images.githubusercontent.com/263461/143722837-b8c09805-8bc1-4364-b538-14caccd85651.png">

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/8986

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
