### PR TITLE
[Keyboard] Xelus Pachi RGB Rev2

### DIFF
--- a/src/xelus/pachi/xelus_pachi_rgb_rev1.json
+++ b/src/xelus/pachi/xelus_pachi_rgb_rev1.json
@@ -1,5 +1,5 @@
 {
-    "name":"Pachi RGB",
+    "name":"Pachi RGB Rev1",
     "vendorId":"0x5845",
     "productId":"0x5052",
     "lighting": {

--- a/src/xelus/pachi/xelus_pachi_rgb_rev2.json
+++ b/src/xelus/pachi/xelus_pachi_rgb_rev2.json
@@ -1,0 +1,250 @@
+{
+  "name":"Pachi RGB Rev2",
+  "vendorId":"0x5845",
+  "productId":"0x5053",
+  "lighting":{
+    "extends":"qmk_rgblight",
+    "underglowEffects":[
+      ["None", 0],
+      ["SOLID_COLOR", 1],
+      ["ALPHAS_MODS", 1],
+      ["GRADIENT_UP_DOWN", 1],
+      ["GRADIENT_LEFT_RIGHT", 1],
+      ["BREATHING", 1],
+      ["BAND_SAT", 1],
+      ["BAND_VAL", 1],
+      ["BAND_PINWHEEL_SAT", 1],
+      ["BAND_PINWHEEL_VAL", 1],
+      ["BAND_SPIRAL_SAT", 1],
+      ["BAND_SPIRAL_VAL", 1],
+      ["CYCLE_ALL", 1],
+      ["CYCLE_LEFT_RIGHT", 1],
+      ["CYCLE_UP_DOWN", 1],
+      ["CYCLE_OUT_IN", 1],
+      ["CYCLE_OUT_IN_DUAL", 1],
+      ["RAINBOW_MOVING_CHEVRON", 1],
+      ["CYCLE_PINWHEEL", 1],
+      ["CYCLE_SPIRAL", 1],
+      ["DUAL_BEACON", 1],
+      ["RAINBOW_BEACON", 1],
+      ["RAINBOW_PINWHEELS", 1],
+      ["RAINDROPS", 1],
+      ["JELLYBEAN_RAINDROPS", 1],
+      ["HUE_BREATHING", 1],
+      ["HUE_PENDULUM", 1],
+      ["HUE_WAVE", 1],
+      ["TYPING_HEATMAP", 1],
+      ["DIGITAL_RAIN", 1],
+      ["SOLID_REACTIVE_SIMPLE", 1],
+      ["SOLID_REACTIVE", 1],
+      ["SOLID_REACTIVE_WIDE", 1],
+      ["SOLID_REACTIVE_MULTIWIDE", 1],
+      ["SOLID_REACTIVE_CROSS", 1],
+      ["SOLID_REACTIVE_MULTICROSS", 1],
+      ["SOLID_REACTIVE_NEXUS", 1],
+      ["SOLID_REACTIVE_MULTINEXUS", 1],
+      ["SPLASH", 1],
+      ["MULTISPLASH", 1],
+      ["SOLID_SPLASH", 1],
+      ["SOLID_MULTISPLASH", 1]
+    ],
+    "supportedLightingValues":[
+      128,
+      129,
+      131
+    ]
+  },
+  "matrix":{
+    "rows":12,
+    "cols":9
+  },
+  "layouts":{
+    "keymap":[
+      [
+        {
+          "c":"#888888"
+        },
+        "0,0",
+        {
+          "x":1,
+          "c":"#cccccc"
+        },
+        "0,1",
+        "1,1",
+        "0,2",
+        "1,2",
+        {
+          "x":0.5,
+          "c":"#aaaaaa"
+        },
+        "0,3",
+        "1,3",
+        "0,4",
+        "1,4",
+        {
+          "x":0.5,
+          "c":"#cccccc"
+        },
+        "0,5",
+        "1,5",
+        "0,6",
+        "1,6",
+        {
+          "x":0.25,
+          "c":"#aaaaaa"
+        },
+        "0,7",
+        "1,7",
+        "0,8    "
+      ],
+      [
+        {
+          "y":0.25,
+          "c":"#cccccc"
+        },
+        "2,0",
+        "3,0",
+        "2,1",
+        "3,1",
+        "2,2",
+        "3,2",
+        "2,3",
+        "3,3",
+        "2,4",
+        "3,4",
+        "2,5",
+        "3,5",
+        "2,6",
+        {
+          "c":"#aaaaaa",
+          "w":2
+        },
+        "3,6",
+        {
+          "x":0.25
+        },
+        "2,7",
+        "3,7",
+        "2,8"
+      ],
+      [
+        {
+          "w":1.5
+        },
+        "4,0",
+        {
+          "c":"#cccccc"
+        },
+        "5,0",
+        "4,1",
+        "5,1",
+        "4,2",
+        "5,2",
+        "4,3",
+        "5,3",
+        "4,4",
+        "5,4",
+        "4,5",
+        "5,5",
+        "4,6",
+        {
+          "w":1.5
+        },
+        "5,6",
+        {
+          "x":0.25,
+          "c":"#aaaaaa"
+        },
+        "4,7",
+        "5,7",
+        "4,8"
+      ],
+      [
+        {
+          "w":1.75
+        },
+        "6,0",
+        {
+          "c":"#cccccc"
+        },
+        "7,0",
+        "6,1",
+        "7,1",
+        "6,2",
+        "7,2",
+        "6,3",
+        "7,3",
+        "6,4",
+        "7,4",
+        "6,5",
+        "7,5",
+        {
+          "c":"#888888",
+          "w":2.25
+        },
+        "7,6"
+      ],
+      [
+        {
+          "c":"#aaaaaa",
+          "w":2.25
+        },
+        "8,0",
+        {
+          "c":"#cccccc"
+        },
+        "9,0",
+        "8,1",
+        "9,1",
+        "8,2",
+        "9,2",
+        "8,3",
+        "9,3",
+        "8,4",
+        "9,4",
+        "8,5",
+        {
+          "c":"#aaaaaa",
+          "w":2.75
+        },
+        "8,6",
+        {
+          "x":1.25
+        },
+        "9,7"
+      ],
+      [
+        {
+          "w":1.5
+        },
+        "10,0",
+        "11,0",
+        {
+          "w":1.5
+        },
+        "10,1",
+        {
+          "c":"#cccccc",
+          "w":7
+        },
+        "11,2",
+        {
+          "c":"#aaaaaa",
+          "w":1.5
+        },
+        "10,5",
+        "10,6",
+        {
+          "w":1.5
+        },
+        "11,6",
+        {
+          "x":0.25
+        },
+        "10,7",
+        "11,7",
+        "10,8"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add Pachi RGB Rev2

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/15141 - keyboard addition

https://github.com/qmk/qmk_firmware/pull/15440 - VID/PID Update since different physical matrix

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
