### PR TITLE
TKC Portico68 v2: Initial support

### DIFF
--- a/src/tkc/portico68v2/portico68v2.json
+++ b/src/tkc/portico68v2/portico68v2.json
@@ -1,0 +1,214 @@
+{
+  "name": "Portico68 v2",
+  "vendorId": "0x544B",
+  "productId": "0x0011",
+  "lighting": {
+      "extends": "qmk_rgblight",
+      "keycodes": "qmk",
+      "underglowEffects": [
+        ["Off", 0],
+        ["Solid Color", 1],
+        ["Alpha Mods", 1],
+        ["Gradient Up-Down", 1],
+        ["Gradient Left-Right", 1],
+        ["Breathing", 1],
+        ["Band Saturation", 1],
+        ["Band Brightness", 1],
+        ["Band Pinwheel Saturation", 1],
+        ["Band Pinwheel Brightness", 1],
+        ["Band Spiral Saturation", 1],
+        ["Band Spiral Brightness", 1],
+        ["Gradient", 1],
+        ["Gradient Cycle Left-Right", 1],
+        ["Gradient Cycle Up-Down", 1],
+        ["Cycle In", 1],
+        ["Cycle In (Dual)", 1],
+        ["Rainbow Chevron", 1],
+        ["Gradient Pinwheel", 1],
+        ["Gradient Spiral", 1],
+        ["Gradient Dual Beacon", 1],
+        ["Gradient Beacon", 1],
+        ["Dual Pinwheel", 1],
+        ["Raindrops", 1],
+        ["Jellybean Raindrops", 1],
+        ["Hue Breathing", 1],
+        ["Hue Bendulum", 1],
+        ["Hue Wave", 1],
+        ["Heatmap", 1],
+        ["Digitial Rain", 1],
+        ["Reactive (Simple)", 1],
+        ["Reactive", 1],
+        ["Reactive Wide", 1],
+        ["Reactive Wide (Multi)", 1],
+        ["Reactive Cross", 1],
+        ["Reactive Cross (Multi)", 1],
+        ["Reactive Nexus", 1],
+        ["Reactive Nexus (Multi)", 1],
+        ["Splash (Multi-Color)", 1],
+        ["Splash (Multi-Color) (Multi)", 1],
+        ["Splash (Solid Color)", 1],
+        ["Splash (Solid Color) (Multi)", 1]
+      ],
+	  "supportedLightingValues": [
+        128,
+        129,
+        131
+      ]
+    },
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap":
+	[
+  [
+    {
+      "c": "#777777"
+    },
+    "0,0",
+    {
+      "c": "#cccccc"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    "0,5",
+    "0,6",
+    "0,7",
+    "0,8",
+    "0,9",
+    "0,10",
+    "0,11",
+    "0,12",
+    {
+      "c": "#aaaaaa",
+      "w": 2
+    },
+    "0,13",
+    "0,14"
+  ],
+  [
+    {
+      "w": 1.5
+    },
+    "1,0",
+    {
+      "c": "#cccccc"
+    },
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "w": 1.5
+    },
+    "1,13",
+    {
+      "c": "#aaaaaa"
+    },
+    "1,14"
+  ],
+  [
+    {
+      "w": 1.75
+    },
+    "2,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    {
+      "c": "#777777",
+      "w": 2.25
+    },
+    "2,12",
+    {
+      "c": "#aaaaaa"
+    },
+    "2,14"
+  ],
+  [
+    {
+      "w": 2.25
+    },
+    "3,0",
+    {
+      "c": "#cccccc"
+    },
+    "3,2",
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6",
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10",
+    "3,11",
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "3,12",
+    {
+      "c": "#777777"
+    },
+    "3,13",
+    {
+      "c": "#aaaaaa"
+    },
+    "3,14"
+  ],
+  [
+    {
+      "w": 1.25
+    },
+    "4,0",
+    {
+      "w": 1.25
+    },
+    "4,1",
+    {
+      "w": 1.25
+    },
+    "4,2",
+    {
+      "w": 6.25
+    },
+    "4,6",
+    {
+      "w": 1.25
+    },
+    "4,10",
+    {
+      "w": 1.25
+    },
+    "4,11",
+    {
+      "x": 0.5,
+      "c": "#777777"
+    },
+    "4,12",
+    "4,13",
+    "4,14"
+  ]
+]
+  }
+}

--- a/src/tkc/portico68v2/portico68v2.json
+++ b/src/tkc/portico68v2/portico68v2.json
@@ -1,7 +1,7 @@
 {
   "name": "Portico68 v2",
   "vendorId": "0x544B",
-  "productId": "0x0011",
+  "productId": "0x0012",
   "lighting": {
       "extends": "qmk_rgblight",
       "keycodes": "qmk",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Initial support for TKC Portico68 v2.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/15916

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
