### PR TITLE
Waffling60 Rev C bugfix, no backlight on board.

### DIFF
--- a/src/4pplet/waffling60_rev_c.json
+++ b/src/4pplet/waffling60_rev_c.json
@@ -2,7 +2,7 @@
     "name": "waffling60 Rev C", 
     "vendorId": "0x4444",
     "productId": "0x0008",
-    "lighting": "qmk_backlight_rgblight",
+    "lighting": "qmk_rgblight",
     "matrix": {"rows": 5, "cols": 14},
     "layouts": {
            "labels": [


### PR DESCRIPTION
## Description

Bugfix, no backlight on this board. Removing option in VIA

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/16191

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ x ] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [ x ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ x ] I have tested this keyboard definition using VIA's "Design" tab.
- [ x ] I have tested this keyboard definition with firmware on a device.
- [ x ] I have assigned alpha keys and modifier keys with the correct colors.
- [ x ] The Vendor ID is not `0xFEED`

Thanks! :)
