### PR TITLE
Add IDOBAO Montex v1rgb

### DIFF
--- a/src/idobao/montex/montex-v1rgb.json
+++ b/src/idobao/montex/montex-v1rgb.json
@@ -1,0 +1,52 @@
+{
+    "name": "IDOBAO Montex RGB",
+    "vendorId": "0x6964",
+    "productId": "0x0127",
+    "lighting": {
+        "extends": "qmk_rgblight",
+        "supportedLightingValues":[
+            128,
+            129,
+            131
+        ],
+        "underglowEffects": [
+            ["None", 0],
+            ["Solid Color", 1],
+            ["Alphas Mods", 1],
+            ["Gradient Up-Down", 1],
+            ["Gradient Left-Right", 1],
+            ["Breathing", 1],
+            ["Cycle All", 1],
+            ["Cycle Left-Right", 1],
+            ["Cycle Up-Down", 1],
+            ["Cycle Out-In", 1],
+            ["Cycle Pinwheel", 1],
+            ["Cycle Spiral", 1],
+            ["Rainbow Beacon", 1],
+            ["Rain Drops", 1],
+            ["JellyBean Rain Drops", 1],
+            ["Hue Breathing", 1],
+            ["Hue Pendulum", 1],
+            ["Hue Wave", 1],
+            ["Pixel Rain", 1],
+            ["Pixel Flow", 1],
+            ["Pixel Fractal", 1],
+            ["Solid Reactive", 1],
+            ["Solid Reactive Wide", 1],
+            ["Solid Reactive Multi-wide", 1],
+            ["Splash", 1],
+            ["Solid Splash", 1]
+        ]
+    },
+    "matrix": { "rows": 6, "cols": 5 },
+    "layouts": {
+        "keymap": [
+            [{"c":"#777777"},"0,0",{"c":"#aaaaaa"},"0,1","0,2","0,3","0,4"],
+            [{"y":0.5,"c":"#cccccc"},"1,0","1,1","1,2","1,3","1,4"],
+            ["2,0","2,1","2,2","2,3",{"h":2},"2,4"],
+            ["3,0","3,1","3,2","3,3"],
+            ["4,0","4,1","4,2","4,3",{"c":"#777777","h":2},"5,3"],
+            [{"c":"#cccccc"},"5,0",{"w":2},"5,1","5,2"]
+        ]
+    }
+}

--- a/src/idobao/montex/montex-v1rgb.json
+++ b/src/idobao/montex/montex-v1rgb.json
@@ -30,7 +30,6 @@
             ["Hue Wave", 1],
             ["Pixel Rain", 1],
             ["Pixel Flow", 1],
-            ["Pixel Fractal", 1],
             ["Solid Reactive", 1],
             ["Solid Reactive Wide", 1],
             ["Solid Reactive Multi-wide", 1],


### PR DESCRIPTION
Add the IDOBAO Montex RGB 40% Numeric keypad

## Description

The IDOBAO Montex RGB is an upgrade to the prior IDOBAO Montex Pad and now add's per-key RGB, leveraging QMK's RGB Matrix library.

## QMK Pull Request 

- https://github.com/qmk/qmk_firmware/pull/15865

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
