### PR TITLE
add fave65h via file

### DIFF
--- a/src/linworks/fave65h/fave65h.json
+++ b/src/linworks/fave65h/fave65h.json
@@ -1,0 +1,238 @@
+{
+    "name": "FAve 65H",
+    "vendorId": "0x4C58",
+    "productId": "0x0007",
+    "matrix": {"rows": 5, "cols": 15},
+    "lighting": {
+      "extends": "qmk_rgblight",
+      "underglowEffects": [
+        ["None", 0],
+        ["Solid Color", 1],
+        ["Vertical Gradient", 1],
+        ["Horizontal Gradient", 1],
+        ["Breathing", 1],
+        ["Colorband - Saturation", 1],
+        ["Colorband - Brightness", 1],
+        ["Pinwheel - Saturation", 1],
+        ["Pinwheel - Brightness", 1],
+        ["Spiral - Saturation", 1],
+        ["Spiral - Brightness", 1],
+        ["Cycle All", 1],
+        ["Cycle Horizontal", 1],
+        ["Cycle Vertical", 1],
+        ["Rainbow Chevron", 1],
+        ["Cycle - In/Out", 1],
+        ["Cycle - In/Out Dual", 1],
+        ["Cycle - Pinwheel", 1],
+        ["Cycle - Spiral", 1],
+        ["Dual Beacon", 1],
+        ["Rainbow Beacon", 1],
+        ["Rainbow Pinwheels", 1],
+        ["Raindrops", 1],
+        ["Jellybean Raindrops", 1],
+        ["Hue Breathing", 1],
+        ["Hue Pendulum", 1],
+        ["Hue Wave", 1],
+        ["Pixel Rain", 1],
+        ["Solid Reactive Simple", 1],
+        ["Solid Reactive", 1],
+        ["Solid Reactive Wide", 1],
+        ["Solid Reactive Multiwide", 1],
+        ["Solid Reactive Cross", 1],
+        ["Solid Reactive Multicross", 1],
+        ["Solid Reactive Nexus", 1],
+        ["Solid Reactive Multinexus", 1],
+        ["Splash", 1],
+        ["Multisplash", 1],
+        ["Solid Splash", 1],
+        ["Solid Multisplash", 1]
+      ],
+      "supportedLightingValues": [
+        128,
+        129,
+        130,
+        131
+      ]
+    },
+    "layouts": {
+      "labels": [
+        "Split Backspace",
+        [
+          "Bottom Row",
+          "Regular",
+          "Tsangan"
+       ]
+      ],
+        "keymap": [
+          [
+            {
+              "c": "#777777"
+            },
+            "0,0",
+            {
+              "c": "#cccccc"
+            },
+            "0,1",
+            "0,2",
+            "0,3",
+            "0,4",
+            "0,5",
+            "0,6",
+            "0,7",
+            "0,8",
+            "0,9",
+            "0,10",
+            "0,11",
+            "0,12",
+            {
+              "w": 2
+            },
+            "0,13\n\n\n0,0",
+            {
+              "c": "#aaaaaa"
+            },
+            "0,14",
+            {
+              "x": 0.75,
+              "c": "#cccccc"
+            },
+            "2,12\n\n\n0,1",
+            "0,13\n\n\n0,1"
+          ],
+          [
+            {
+              "c": "#aaaaaa",
+              "w": 1.5
+            },
+            "1,0",
+            {
+              "c": "#cccccc"
+            },
+            "1,1",
+            "1,2",
+            "1,3",
+            "1,4",
+            "1,5",
+            "1,6",
+            "1,7",
+            "1,8",
+            "1,9",
+            "1,10",
+            "1,11",
+            "1,12",
+            {
+              "w": 1.5
+            },
+            "1,13",
+            {
+              "c": "#aaaaaa"
+            },
+            "1,14"
+          ],
+          [
+            {
+              "w": 1.75
+            },
+            "2,0",
+            {
+              "c": "#cccccc"
+            },
+            "2,1",
+            "2,2",
+            "2,3",
+            "2,4",
+            "2,5",
+            "2,6",
+            "2,7",
+            "2,8",
+            "2,9",
+            "2,10",
+            "2,11",
+            {
+              "c": "#777777",
+              "w": 2.25
+            },
+            "2,13",
+            {
+              "c": "#aaaaaa"
+            },
+            "2,14"
+          ],
+          [
+            {
+              "w": 2.25
+            },
+            "3,0",
+            {
+              "c": "#cccccc"
+            },
+            "3,1",
+            "3,2",
+            "3,3",
+            "3,4",
+            "3,5",
+            "3,6",
+            "3,7",
+            "3,8",
+            "3,9",
+            "3,10",
+            {
+              "c": "#aaaaaa",
+              "w": 1.75
+            },
+            "3,12",
+            "3,13",
+            "3,14"
+          ],
+          [
+            {
+              "w": 1.25
+            },
+            "4,0\n\n\n1,0",
+            {
+              "w": 1.25
+            },
+            "4,1\n\n\n1,0",
+            {
+              "w": 1.25
+            },
+            "4,2\n\n\n1,0",
+            {
+              "c": "#777777",
+              "w": 6.25
+            },
+            "4,6\n\n\n1,0",
+            {
+              "c": "#aaaaaa",
+              "w": 1.25
+            },
+            "4,8",
+            {
+              "w": 1.25
+            },
+            "4,10",
+            {
+              "x": 0.5
+            },
+            "4,12",
+            "4,13",
+            "4,14"
+          ],
+          [
+            {
+              "w": 1.5
+            },
+            "4,0\n\n\n1,1",
+            {
+              "w": 1.5
+            },
+            "4,0\n\n\n1,1",
+            {
+              "c": "#777777",
+              "w": 7
+            },
+            "4,6\n\n\n1,1"
+          ]
+        ]
+    }
+}


### PR DESCRIPTION
## Description

Via config for the Linworks Fave 65H
Has per key RGB and Underglow

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/17147

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
