### PR TITLE
Enable QMK backlight on rouge87 and rogue87 PCB

### DIFF
--- a/src/mechlovin/rogue87/rogue87.json
+++ b/src/mechlovin/rogue87/rogue87.json
@@ -2,7 +2,7 @@
     "name": "Rogue87",
     "vendorId": "0x4D4C",
     "productId": "0x8704",
-    "lighting": "none",
+    "lighting": "qmk_backlight",
     "matrix": {"rows": 6, "cols": 17},
     "layouts": {
       "labels": [

--- a/src/mechlovin/rouge87/rouge87.json
+++ b/src/mechlovin/rouge87/rouge87.json
@@ -2,7 +2,7 @@
     "name": "Rouge87",
     "vendorId": "0x4D4C",
     "productId": "0x8703",
-    "lighting": "none",
+    "lighting": "qmk_backlight",
     "matrix": {"rows": 6, "cols": 17},
     "layouts": {
       "labels": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enable QMK Backlight on Rouge87 and Rogue87 PCB.
Thanks
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
