### PR TITLE
Downgrade SP64 to v2

### DIFF
--- a/src/YMDK/sp64/sp64.json
+++ b/src/YMDK/sp64/sp64.json
@@ -2,16 +2,8 @@
   "name": "YMDK SP64",
   "vendorId": "0x594D",
   "productId": "0x5364",
-  "firmwareVersion": 0,
   "lighting": "qmk_rgblight",
   "matrix": { "rows": 6, "cols": 15 },
-  "menus": [
-    "via/keymap",
-    "via/macros",
-    "via/save_load",
-    "core/qmk_rgblight"
-  ],
-  "keycodes": ["via/keycodes", "via/qmk_lighting"],
   "layouts": {
     "keymap": [
       [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

I mistakenly allowed merged a v3 definition.
Currently all v3 definitions are autogenerated. As v3 is still WIP I am downgrading SP64 to v2.

@bbeesley Sorry I should have spotted this and told you at the PR.

Our CI has now been updated to also spot for this.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
