### PR TITLE
Add rgb support for zoom87

### DIFF
--- a/src/meletrix/zoom87/zoom87.json
+++ b/src/meletrix/zoom87/zoom87.json
@@ -2,7 +2,7 @@
     "name": "Zoom 87",
     "vendorId": "0x906F",
     "productId": "0x0007",
-    "lighting": "none",
+    "lighting": "qmk_rgblight",
     "matrix": {
         "rows": 6,
         "cols": 17

--- a/src/meletrix/zoom87/zoom87.json
+++ b/src/meletrix/zoom87/zoom87.json
@@ -1,5 +1,5 @@
 {
-    "name": "Promise 87",
+    "name": "Zoom 87",
     "vendorId": "0x906F",
     "productId": "0x0007",
     "lighting": "none",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add rgb support for zoom87
<!--- Describe your changes in detail here. -->

## QMK Pull Request 
https://github.com/qmk/qmk_firmware/pull/17831
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
