### PR TITLE
Fixed 40percentclub/sixpack vendor ID

### DIFF
--- a/src/40percentclub/sixpack/sixpack.json
+++ b/src/40percentclub/sixpack/sixpack.json
@@ -1,6 +1,6 @@
 {
   "name": "Six Pack",
-  "vendorId": "0x3430",
+  "vendorId": "0x4025",
   "productId": "0x5350",
   "lighting": "qmk_backlight",
   "matrix": {"rows": 2, "cols": 3},


### PR DESCRIPTION
## Description

Someone changed the vendor ID of several 40percent.club keyboards in QMK (pull request below). This updates VIA to match that change.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/15465

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
