### PR TITLE
Add 6key macropad

### DIFF
--- a/src/handwired/6key/6key.json
+++ b/src/handwired/6key/6key.json
@@ -1,0 +1,24 @@
+{
+  "name": "6key",
+  "vendorId": "0xD143",
+  "productId": "0x0007",
+  "lighting": "none",
+  "matrix": {
+    "rows": 2,
+    "cols": 3
+  },
+  "layouts": {
+    "keymap": [
+      [
+        "0,0",
+        "0,1",
+        "0,2"
+      ],
+      [
+        "1,0",
+        "1,1",
+        "1,2"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds a VIA layout for the 6key macropad

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/18082

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
