### PR TITLE
Add VIA support for Keychron Q0

### DIFF
--- a/src/keychron/q0/rev_0130.json
+++ b/src/keychron/q0/rev_0130.json
@@ -1,0 +1,80 @@
+{
+  "name": "Keychron Q0",
+  "vendorId": "0x3434",
+  "productId": "0x0130",
+  "lighting": {
+  "extends": "qmk_rgblight",
+  "underglowEffects": [
+      ["None", 0],
+      ["SOLID_COLOR", 1],
+      ["BREATHING", 1],
+      ["CYCLE_ALL", 1],
+      ["CYCLE_LEFT_RIGHT", 1],
+      ["CYCLE_UP_DOWN", 1],
+      ["RAINBOW_MOVING_CHEVRON", 1],
+      ["CYCLE_OUT_IN", 1],
+      ["CYCLE_OUT_IN_DUAL", 1],
+      ["CYCLE_PINWHEEL", 1],
+      ["CYCKE_SPIRAL", 1],
+      ["DUAL_BEACON", 1],
+      ["RAINBOW_BEACON", 1],
+      ["RAINDROPS", 1]
+    ]
+  },
+  "matrix": {
+    "rows": 6,
+    "cols": 4
+  },
+  "layouts": {
+    "keymap":
+    [
+      [
+        "0,0",
+        "0,1",
+        "0,2",
+        "0,3"
+      ],
+      [
+        "1,0",
+        "1,1",
+        "1,2",
+        "1,3"
+      ],
+      [
+        "2,0",
+        "2,1",
+        "2,2"
+      ],
+      [
+        "3,0",
+        "3,1",
+        "3,2",
+        {
+          "h": 2,
+          "y": -1
+        },
+        "2,3"
+      ],
+      [
+        {
+          "y": 1
+        },
+        "4,0",
+        "4,1",
+        "4,2"
+      ],
+      [
+        {
+          "w": 2
+        },
+        "5,0",
+        "5,2",
+        {
+          "h": 2,
+          "y": -1
+        },
+        "4,3"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR is meant to add VIA support for the Keychron Q0 which was just added to the main QMK repo as of 11:53AM PST, 9/24.
<!--- Describe your changes in detail here. -->

## QMK Pull Request 
<!--- VIA support for new keyboards MUST be in QMK master already -->
Add support to Keychron Q0 ([#18348](https://github.com/qmk/qmk_firmware/pull/18348))

## Checklist
- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
