### PR TITLE
updates to 1up product line

### DIFF
--- a/src/1upkeyboards/pi60_hse/pi60_hse.json
+++ b/src/1upkeyboards/pi60_hse/pi60_hse.json
@@ -1,0 +1,248 @@
+{
+    "name": "pi60_hse",
+    "vendorId": "0x6F75",
+    "productId": "0x5603",
+    "matrix": { "rows": 6, "cols": 14},
+    "lighting": {
+      "extends":"qmk_rgblight",
+      "underglowEffects": [
+        ["None", 0],
+        ["SOLID_COLOR", 1],
+        ["ALPHAS_MODS", 1],
+        ["GRADIENT_UP_DOWN", 1],
+        ["GRADIENT_LEFT_RIGHT", 1],
+        ["BREATHING", 1],
+        ["BAND_SAT", 1],
+        ["BAND_VAL", 1],
+        ["BAND_PINWHEEL_SAT", 1],
+        ["BAND_PINWHEEL_VAL", 1],
+        ["BAND_SPIRAL_SAT", 1],
+        ["BAND_SPIRAL_VAL", 1],
+        ["CYCLE_ALL", 1],
+        ["CYCLE_LEFT_RIGHT", 1],
+        ["CYCLE_UP_DOWN", 1],
+        ["RAINBOW_MOVING_CHEVRON", 1],
+        ["CYCLE_OUT_IN", 1],
+        ["CYCLE_OUT_IN_DUAL", 1],
+        ["CYCLE_PINWHEEL", 1],
+        ["CYCLE_SPIRAL", 1],
+        ["DUAL_BEACON", 1],
+        ["RAINBOW_BEACON", 1],
+        ["RAINBOW_PINWHEELS", 1],
+        ["RAINDROPS", 1],
+        ["JELLYBEAN_RAINDROPS", 1],
+        ["HUE_BREATHING", 1],
+        ["HUE_PENDULUM", 1],
+        ["HUE_WAVE", 1],
+        ["PIXEL_RAIN", 1],
+        ["PIXEL_FLOW", 1],
+        ["PIXEL_FRACTAL", 1],
+        ["TYPING_HEATMAP", 1],
+        ["DIGITAL_RAIN", 1],
+        ["SOLID_REACTIVE_SIMPLE", 1],
+        ["SOLID_REACTIVE", 1],
+        ["SOLID_REACTIVE_WIDE", 1],
+        ["SOLID_REACTIVE_MULTIWIDE", 1],
+        ["SOLID_REACTIVE_CROSS", 1],
+        ["SOLID_REACTIVE_MULTICROSS", 1],
+        ["SOLID_REACTIVE_NEXUS", 1],
+        ["SOLID_REACTIVE_MULTINEXUS", 1],
+        ["SPLASH", 1],
+        ["MULTISPLASH", 1],
+        ["SOLID_SPLASH", 1],
+        ["SOLID_MULTISPLASH", 1]
+      ],
+      "supportedLightingValues": [
+        128,
+        129,
+        131
+      ]
+    },
+    "layouts": {
+      "labels": [
+        "Split Backspace",
+        "Split Shift",
+        "7u Space"
+      ],
+      "keymap": [
+        [
+          {
+            "c": "#777777"
+          },
+          "0,0",
+          {
+            "c": "#cccccc"
+          },
+          "0,1",
+          "0,2",
+          "0,3",
+          "0,4",
+          "0,5",
+          "0,6",
+          "0,7",
+          "0,8",
+          "0,9",
+          "0,10",
+          "0,11",
+          "0,12",
+          {
+            "c": "#aaaaaa",
+            "w": 2
+          },
+          "0,13\n\n\n0,0",
+          {
+            "x": 0.25,
+            "c": "#cccccc"
+          },
+          "0,13\n\n\n0,1",
+          "1,13\n\n\n0,1"
+        ],
+        [
+          {
+            "c": "#aaaaaa",
+            "w": 1.5
+          },
+          "1,0",
+          {
+            "c": "#cccccc"
+          },
+          "1,1",
+          "1,2",
+          "1,3",
+          "1,4",
+          "1,5",
+          "1,6",
+          "1,7",
+          "1,8",
+          "1,9",
+          "1,10",
+          "1,11",
+          "1,12",
+          {
+            "c": "#aaaaaa",
+            "w": 1.5
+          },
+          "2,12"
+        ],
+        [
+          {
+            "w": 1.75
+          },
+          "2,0",
+          {
+            "c": "#cccccc"
+          },
+          "2,1",
+          "2,2",
+          "2,3",
+          "2,4",
+          "2,5",
+          "2,6",
+          "2,7",
+          "2,8",
+          "2,9",
+          "2,10",
+          "2,11",
+          {
+            "c": "#777777",
+            "w": 2.25
+          },
+          "2,13"
+        ],
+        [
+          {
+            "c": "#aaaaaa",
+            "w": 2.25
+          },
+          "3,0",
+          {
+            "c": "#cccccc"
+          },
+          "3,1",
+          "3,2",
+          "3,3",
+          "3,4",
+          "3,5",
+          "3,6",
+          "3,7",
+          "3,8",
+          "3,9",
+          "3,10",
+          {
+            "c": "#aaaaaa",
+            "w": 2.75
+          },
+          "3,12\n\n\n1,0",
+          {
+            "x": 0.25,
+            "w": 1.75
+          },
+          "3,12\n\n\n1,1",
+          "3,13\n\n\n1,1"
+        ],
+        [
+          {
+            "w": 1.25
+          },
+          "4,0\n\n\n2,0",
+          {
+            "w": 1.25
+          },
+          "4,1\n\n\n2,0",
+          {
+            "w": 1.25
+          },
+          "4,2\n\n\n2,0",
+          {
+            "c": "#cccccc",
+            "w": 6.25
+          },
+          "5,5\n\n\n2,0",
+          {
+            "c": "#aaaaaa",
+            "w": 1.25
+          },
+          "5,9\n\n\n2,0",
+          {
+            "w": 1.25
+          },
+          "5,10\n\n\n2,0",
+          {
+            "w": 1.25
+          },
+          "5,12\n\n\n2,0",
+          {
+            "w": 1.25
+          },
+          "5,13\n\n\n2,0"
+        ],
+        [
+          {
+            "y": 0.25,
+            "w": 1.5
+          },
+          "4,0\n\n\n2,1",
+          "4,1\n\n\n2,1",
+          {
+            "w": 1.5
+          },
+          "4,2\n\n\n2,1",
+          {
+            "c": "#cccccc",
+            "w": 7
+          },
+          "5,5\n\n\n2,1",
+          {
+            "c": "#aaaaaa",
+            "w": 1.5
+          },
+          "5,10\n\n\n2,1",
+          "5,12\n\n\n2,1",
+          {
+            "w": 1.5
+          },
+          "5,13\n\n\n2,1"
+        ]
+      ]
+    }
+  }

--- a/src/1upkeyboards/sweet16/sweet16v2.json
+++ b/src/1upkeyboards/sweet16/sweet16v2.json
@@ -1,73 +1,103 @@
 {
-    "name": "sweet16 v2",
+    "name": "sweet16v2",
     "vendorId": "0x6F75",
-    "productId": "0x0162",
-    "lighting": "qmk_backlight",
-    "matrix": {
-      "rows": 4,
-      "cols": 4
+    "productId": "0x5518",
+    "matrix": { "rows": 4, "cols": 4},
+    "lighting": {
+      "extends":"qmk_rgblight",
+      "underglowEffects": [
+        ["None", 0],
+        ["SOLID_COLOR", 1],
+        ["ALPHAS_MODS", 1],
+        ["GRADIENT_UP_DOWN", 1],
+        ["GRADIENT_LEFT_RIGHT", 1],
+        ["BREATHING", 1],
+        ["BAND_SAT", 1],
+        ["BAND_VAL", 1],
+        ["BAND_PINWHEEL_SAT", 1],
+        ["BAND_PINWHEEL_VAL", 1],
+        ["BAND_SPIRAL_SAT", 1],
+        ["BAND_SPIRAL_VAL", 1],
+        ["CYCLE_ALL", 1],
+        ["CYCLE_LEFT_RIGHT", 1],
+        ["CYCLE_UP_DOWN", 1],
+        ["RAINBOW_MOVING_CHEVRON", 1],
+        ["CYCLE_OUT_IN", 1],
+        ["CYCLE_OUT_IN_DUAL", 1],
+        ["CYCLE_PINWHEEL", 1],
+        ["CYCLE_SPIRAL", 1],
+        ["DUAL_BEACON", 1],
+        ["RAINBOW_BEACON", 1],
+        ["RAINBOW_PINWHEELS", 1],
+        ["RAINDROPS", 1],
+        ["JELLYBEAN_RAINDROPS", 1],
+        ["HUE_BREATHING", 1],
+        ["HUE_PENDULUM", 1],
+        ["HUE_WAVE", 1],
+        ["PIXEL_RAIN", 1],
+        ["PIXEL_FLOW", 1],
+        ["PIXEL_FRACTAL", 1],
+        ["TYPING_HEATMAP", 1],
+        ["DIGITAL_RAIN", 1],
+        ["SOLID_REACTIVE_SIMPLE", 1],
+        ["SOLID_REACTIVE", 1],
+        ["SOLID_REACTIVE_WIDE", 1],
+        ["SOLID_REACTIVE_MULTIWIDE", 1],
+        ["SOLID_REACTIVE_CROSS", 1],
+        ["SOLID_REACTIVE_MULTICROSS", 1],
+        ["SOLID_REACTIVE_NEXUS", 1],
+        ["SOLID_REACTIVE_MULTINEXUS", 1],
+        ["SPLASH", 1],
+        ["MULTISPLASH", 1],
+        ["SOLID_SPLASH", 1],
+        ["SOLID_MULTISPLASH", 1]
+      ],
+      "supportedLightingValues": [
+        128,
+        129,
+        131
+      ]
     },
     "layouts": {
       "labels": [
-        "2u Top Right",
-        "2u Bottom Left",
-        "2u Bottom Right"
+        "Encoder 1",
+        "Encoder 2"
       ],
-
       "keymap": [
         [
-          {
-            "x": 2.5
-          },
-          "0,0",
+          "0,0\n\n\n0,1\n\n\n\n\n\ne0",
+          "0,0\n\n\n0,0",
           "0,1",
           "0,2",
-          "0,3\n\n\n0,0",
-          {
-            "x": 0.5,
-            "c": "#aaaaaa",
-            "h": 2
-          },
-          "0,3\n\n\n0,1"
+          "0,3\n\n\n1,0",
+          "0,3\n\n\n1,1\n\n\n\n\n\ne1"
         ],
         [
           {
-            "x": 2.5,
-            "c": "#cccccc"
+            "x": 1
           },
           "1,0",
           "1,1",
           "1,2",
-          "1,3\n\n\n0,0"
+          "1,3"
         ],
         [
           {
-            "x": 2.5
+            "x": 1
           },
           "2,0",
           "2,1",
           "2,2",
-          "2,3\n\n\n2,0",
-          {
-            "x": 0.5,
-            "c": "#777777",
-            "h": 2
-          },
-          "2,3\n\n\n2,1"
+          "2,3"
         ],
         [
           {
-            "c": "#cccccc",
-            "w": 2
+            "x": 1
           },
-          "3,1\n\n\n1,1",
-          {
-            "x": 0.5
-          },
-          "3,0\n\n\n1,0",
-          "3,1\n\n\n1,0",
+          "3,0",
+          "3,1",
           "3,2",
-          "3,3\n\n\n2,0"
+          "3,3"
         ]
       ]
     }


### PR DESCRIPTION
Removed old sweet16v2, product was never released. Replaced with current sweet16v2.

Added pi60_hse json

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/tree/master/keyboards/1upkeyboards/sweet16v2

https://github.com/qmk/qmk_firmware/tree/master/keyboards/1upkeyboards/pi60_hse

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
