### PR TITLE
Ploopy Trackball Thumb

### DIFF
--- a/src/ploopyco/trackball/trackball_thumb.json
+++ b/src/ploopyco/trackball/trackball_thumb.json
@@ -1,0 +1,48 @@
+{
+    "name": "PloopyCo Trackball Thumb",
+    "vendorId": "0x5043",
+    "productId": "0x5C46",
+    "lighting": "none",
+    "customKeycodes": [
+        {"name": "DPI Config", "title": "DPI Config", "shortName": "DPI"},
+        {"name": "Drag Scroll", "title": "Drag Scroll", "shortName": "DragScl"}
+    ],
+    "matrix": { "rows": 1, "cols": 6 },
+    "layouts": {
+        "keymap": [
+  [
+    "0,0",
+    {
+      "h": 2
+    },
+    "0,2",
+    {
+      "x": 1,
+      "h": 2
+    },
+    "0,4"
+  ],
+  [
+    {
+      "y": -0.75,
+      "x": 2,
+      "h": 1.5
+    },
+    "0,3"
+  ],
+  [
+    {
+      "y": -0.75,
+      "x": 4
+    },
+    "0,5"
+  ],
+  [
+    {
+      "y": -0.5
+    },
+    "0,1"
+  ]
+]
+    }
+}


### PR DESCRIPTION

## Description

As title.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/18214

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
