### PR TITLE
Add Octopad+ keyboard

### DIFF
--- a/src/nightly_boards/octopadplus.json
+++ b/src/nightly_boards/octopadplus.json
@@ -1,0 +1,38 @@
+{
+  "name": "Octopad+",
+  "vendorId": "0xD812",
+  "productId": "0x0014",
+  "lighting": "qmk_rgblight",
+  "matrix": {
+    "rows": 2,
+    "cols": 6
+  },
+  "layouts": {
+    "labels": [
+    ],
+    "keymap": [
+  [
+    "0,4\n\n\n\n\n\n\n\n\nE0",
+    {
+      "x": 2
+    },
+    "1,5\n\n\n\n\n\n\n\n\nE1"
+  ],
+  [
+    {
+      "y": 0.25
+    },
+    "0,0",
+    "0,1",
+    "0,2",
+    "0,3"
+  ],
+  [
+    "1,0",
+    "1,1",
+    "1,2",
+    "1,3"
+  ]
+]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/18484

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
