### PR TITLE
Add Binepad BN006

### DIFF
--- a/src/binepad/bn006/bn006.json
+++ b/src/binepad/bn006/bn006.json
@@ -1,0 +1,32 @@
+{
+    "name": "BN006",
+    "vendorId": "0x4249",
+    "productId": "0x426E",
+    "lighting": {
+        "extends": "qmk_rgblight",
+        "supportedLightingValues": [
+            128,
+            129,
+            130,
+            131
+        ],
+        "underglowEffects": [
+            ["0. None", 0],
+            ["1. Solid Color", 1],
+            ["2. Gradient Up & Down", 1],
+            ["3. Gradient Left & Right", 1],
+            ["4. Breathing", 1],
+            ["5. Reactive Simple", 1],
+            ["6. Reactive Solid", 1],
+            ["7. Splash", 1],
+            ["8. Solid Splash", 1]
+        ]
+    },
+    "matrix": { "rows": 2, "cols": 3 },
+    "layouts":{
+        "keymap":[
+            [{"c":"#cccccc"},"0,0","0,1","0,2"],
+            ["1,0","1,1","1,2"]
+        ]
+    }
+}


### PR DESCRIPTION

## Description

Add Binepad BN006 macropad available at https://www.binepad.com/bn006

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/18810

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
