### PR TITLE
Add VIA support for Zed60 

### DIFF
--- a/v3/mechlovin/zed60/zed60.json
+++ b/v3/mechlovin/zed60/zed60.json
@@ -1,0 +1,332 @@
+{
+  "name": "Zed60 Rev.1",
+  "vendorId": "0x4D4C",
+  "productId": "0x0602",
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "RGB Underglow",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgblight_brightness", 2, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgblight_effect", 2, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Breathing 1",
+                "Breathing 2",
+                "Breathing 3",
+                "Breathing 4",
+                "Rainbow Mood 1",
+                "Rainbow Mood 2",
+                "Rainbow Mood 3",
+                "Rainbow Swirl 1",
+                "Rainbow Swirl 2",
+                "Rainbow Swirl 3",
+                "Rainbow Swirl 4",
+                "Rainbow Swirl 5",
+                "Rainbow Swirl 6",
+                "Snake 1",
+                "Snake 2",
+                "Snake 3",
+                "Snake 4",
+                "Snake 5",
+                "Snake 6",
+                "Knight 1",
+                "Knight 2",
+                "Knight 3",
+                "Christmas",
+                "Gradient 1",
+                "Gradient 2",
+                "Gradient 3",
+                "Gradient 4",
+                "Gradient 5",
+                "Gradient 6",
+                "Gradient 7",
+                "Gradient 8",
+                "Gradient 9",
+                "Gradient 10",
+                "RGB Test",
+                "Alternating",
+                "Twinkle 1",
+                "Twinkle 2",
+                "Twinkle 3",
+                "Twinkle 4",
+                "Twinkle 5",
+                "Twinkle 6"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgblight_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 3],
+              "content": ["id_qmk_rgblight_effect_speed", 2, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgblight_effect} != 6 && {id_qmk_rgblight_effect} != 7 && {id_qmk_rgblight_effect} != 8 && {id_qmk_rgblight_effect} != 9 && {id_qmk_rgblight_effect} != 10 && {id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 11 && {id_qmk_rgblight_effect} != 12 && {id_qmk_rgblight_effect} != 13 && {id_qmk_rgblight_effect} != 14 && {id_qmk_rgblight_effect} != 35",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgblight_color", 2, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "matrix": {"rows": 5, "cols": 14},
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      "2.75U Right Shift",
+      [
+        "Bottom Row",
+        "6.25U",
+        "7U",
+        "HHKB"
+       ],
+      "Left Shift ISO",
+      "Enter ISO"
+    ],
+    "keymap": [
+      [
+        {
+          "x": 2.5,
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13\n\n\n0,0",
+        {
+          "x": 0.25
+        },
+        "0,13\n\n\n0,1",
+        "2,12\n\n\n0,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,13\n\n\n4,0",
+        {
+          "x": 1.25,
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,13\n\n\n4,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13\n\n\n4,0",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "2,13\n\n\n4,1"
+      ],
+      [
+        {
+          "w": 1.25
+        },
+        "3,0\n\n\n3,1",
+        "3,1\n\n\n3,1",
+        {
+          "x": 0.25,
+          "w": 2.25
+        },
+        "3,0\n\n\n3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,12\n\n\n1,0",
+        "3,13\n\n\n1,0",
+        {
+          "x": 0.25,
+          "w": 2.75
+        },
+        "3,12\n\n\n1,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.25
+        },
+        "4,0\n\n\n2,0",
+        {
+          "w": 1.25
+        },
+        "4,1\n\n\n2,0",
+        {
+          "w": 1.25
+        },
+        "4,2\n\n\n2,0",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "4,6\n\n\n2,0",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,10\n\n\n2,0",
+        {
+          "w": 1.25
+        },
+        "4,11\n\n\n2,0",
+        {
+          "w": 1.25
+        },
+        "4,12\n\n\n2,0",
+        {
+          "w": 1.25
+        },
+        "4,13\n\n\n2,0"
+      ],
+      [
+        {
+          "y": 0.5,
+          "x": 2.5,
+          "w": 1.5
+        },
+        "4,0\n\n\n2,1",
+        "4,1\n\n\n2,1",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n2,1",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n2,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n2,1",
+        "4,12\n\n\n2,1",
+        {
+          "w": 1.5
+        },
+        "4,13\n\n\n2,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5,
+          "d": true
+        },
+        "4,0\n\n\n2,2",
+        "4,1\n\n\n2,2",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n2,2",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n2,2",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n2,2",
+        "4,12\n\n\n2,2",
+        {
+          "w": 1.5,
+          "d": true
+        },
+        "4,13\n\n\n2,2"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add Zed60 Rev. 1 to VIA
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
qmk/qmk_firmware#17304 (merged)
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
