### PR TITLE
Add gmmk2 p65/p96 iso and ansi v3 json config

### DIFF
--- a/v3/gmmk/gmmk2/p65/ansi/p65_ansi.json
+++ b/v3/gmmk/gmmk2/p65/ansi/p65_ansi.json
@@ -1,0 +1,236 @@
+{
+  "name": "GMMK V2 65 ANSI",
+  "vendorId": "0x320F",
+  "productId": "0x5045",
+  "keycodes": ["qmk_lighting"],
+  "menus": [{
+    "label": "Lighting",
+    "content": [{
+      "label": "Backlight",
+      "content": [{
+          "label": "Brightness",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+        },
+        {
+          "label": "Effect",
+          "type": "dropdown",
+          "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+          "options": [
+            ["NONE", 0],
+            ["SOLID_COLOR", 1],
+            ["ALPHAS_MODS", 2],
+            ["GRADIENT_UP_DOWN", 3],
+            ["GRADIENT_LEFT_RIGHT", 4],
+            ["BREATHING", 5],
+            ["BAND_SAT", 6],
+            ["BAND_VAL", 7],
+            ["BAND_PINWHEEL_SAT", 8],
+            ["BAND_PINWHEEL_VAL", 9],
+            ["BAND_SPIRAL_SAT", 10],
+            ["BAND_SPIRAL_VAL", 11],
+            ["CYCLE_ALL", 12],
+            ["CYCLE_LEFT_RIGHT", 13],
+            ["CYCLE_UP_DOWN", 14],
+            ["CYCLE_OUT_IN", 15],
+            ["CYCLE_OUT_IN_DUAL", 16],
+            ["RAINBOW_MOVING_CHEVRON", 17],
+            ["CYCLE_PINWHEEL", 18],
+            ["CYCLE_SPIRAL", 19],
+            ["DUAL_BEACON", 20],
+            ["RAINBOW_BEACON", 21],
+            ["RAINBOW_PINWHEELS", 22],
+            ["RAINDROPS", 23],
+            ["JELLYBEAN_RAINDROPS", 24],
+            ["HUE_BREATHING", 25],
+            ["HUE_PENDULUM", 26],
+            ["HUE_WAVE", 27],
+            ["PIXEL_FRACTAL", 28],
+            ["PIXEL_FLOW", 29],
+            ["PIXEL_RAIN", 30]
+          ]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} >= 3 && {id_qmk_rgb_matrix_effect} <= 4",
+          "label": "Gradiant Size",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 3 && {id_qmk_rgb_matrix_effect} != 4",
+          "label": "Effect Speed",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+          "label": "Color",
+          "type": "color",
+          "content": ["id_qmk_rgb_matrix_color", 3, 4]
+        }
+      ]
+    }]
+  }],
+  "matrix": {
+    "rows": 9,
+    "cols": 8
+  },
+  "layouts": {
+    "keymap": [
+      [{
+          "c": "#777777"
+        },
+        "1,3",
+        {
+          "c": "#cccccc"
+        },
+        "1,7",
+        "2,7",
+        "3,7",
+        "4,7",
+        "4,6",
+        "5,6",
+        "5,7",
+        "6,7",
+        "7,7",
+        "8,7",
+        "8,6",
+        "6,6",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "7,1",
+        {
+          "c": "#cccccc"
+        },
+        "2,5"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,0",
+        "2,0",
+        "3,0",
+        "4,0",
+        "4,1",
+        "5,1",
+        "5,0",
+        "6,0",
+        "7,0",
+        "8,0",
+        "8,1",
+        "6,1",
+        {
+          "w": 1.5
+        },
+        "7,6",
+        "2,6"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "2,2",
+        "3,2",
+        "4,2",
+        "4,3",
+        "5,3",
+        "5,2",
+        "6,2",
+        "7,2",
+        "8,2",
+        "8,3",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "8,4",
+        {
+          "c": "#cccccc"
+        },
+        "6,5"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,4",
+        "2,4",
+        "3,4",
+        "4,4",
+        "4,5",
+        "5,5",
+        "5,4",
+        "6,4",
+        "7,4",
+        "8,5",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "0,7",
+        {
+          "c": "#777777"
+        },
+        "3,5",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "0,6",
+        {
+          "w": 1.25
+        },
+        "1,5",
+        {
+          "w": 1.25
+        },
+        "2,3",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "3,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "3,6",
+        {
+          "w": 1.25
+        },
+        "3,3",
+        {
+          "x": 0.5,
+          "c": "#777777"
+        },
+        "0,3",
+        "7,3",
+        "0,5"
+      ]
+    ]
+  }
+}

--- a/v3/gmmk/gmmk2/p65/iso/p65_iso.json
+++ b/v3/gmmk/gmmk2/p65/iso/p65_iso.json
@@ -1,0 +1,242 @@
+{
+  "name": "GMMK V2 65 ISO",
+  "vendorId": "0x320F",
+  "productId": "0x504A",
+  "keycodes": ["qmk_lighting"],
+  "menus": [{
+    "label": "Lighting",
+    "content": [{
+      "label": "Backlight",
+      "content": [{
+          "label": "Brightness",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+        },
+        {
+          "label": "Effect",
+          "type": "dropdown",
+          "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+          "options": [
+            ["NONE", 0],
+            ["SOLID_COLOR", 1],
+            ["ALPHAS_MODS", 2],
+            ["GRADIENT_UP_DOWN", 3],
+            ["GRADIENT_LEFT_RIGHT", 4],
+            ["BREATHING", 5],
+            ["BAND_SAT", 6],
+            ["BAND_VAL", 7],
+            ["BAND_PINWHEEL_SAT", 8],
+            ["BAND_PINWHEEL_VAL", 9],
+            ["BAND_SPIRAL_SAT", 10],
+            ["BAND_SPIRAL_VAL", 11],
+            ["CYCLE_ALL", 12],
+            ["CYCLE_LEFT_RIGHT", 13],
+            ["CYCLE_UP_DOWN", 14],
+            ["CYCLE_OUT_IN", 15],
+            ["CYCLE_OUT_IN_DUAL", 16],
+            ["RAINBOW_MOVING_CHEVRON", 17],
+            ["CYCLE_PINWHEEL", 18],
+            ["CYCLE_SPIRAL", 19],
+            ["DUAL_BEACON", 20],
+            ["RAINBOW_BEACON", 21],
+            ["RAINBOW_PINWHEELS", 22],
+            ["RAINDROPS", 23],
+            ["JELLYBEAN_RAINDROPS", 24],
+            ["HUE_BREATHING", 25],
+            ["HUE_PENDULUM", 26],
+            ["HUE_WAVE", 27],
+            ["PIXEL_FRACTAL", 28],
+            ["PIXEL_FLOW", 29],
+            ["PIXEL_RAIN", 30]
+          ]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} >= 3 && {id_qmk_rgb_matrix_effect} <= 4",
+          "label": "Gradiant Size",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 3 && {id_qmk_rgb_matrix_effect} != 4",
+          "label": "Effect Speed",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+          "label": "Color",
+          "type": "color",
+          "content": ["id_qmk_rgb_matrix_color", 3, 4]
+        }
+      ]
+    }]
+  }],
+  "matrix": {
+    "rows": 9,
+    "cols": 8
+  },
+  "layouts": {
+    "keymap": [
+      [{
+          "c": "#777777"
+        },
+        "1,3",
+        {
+          "c": "#cccccc"
+        },
+        "1,7",
+        "2,7",
+        "3,7",
+        "4,7",
+        "4,6",
+        "5,6",
+        "5,7",
+        "6,7",
+        "7,7",
+        "8,7",
+        "8,6",
+        "6,6",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "7,1",
+        {
+          "c": "#cccccc"
+        },
+        "2,5"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,0",
+        "2,0",
+        "3,0",
+        "4,0",
+        "4,1",
+        "5,1",
+        "5,0",
+        "6,0",
+        "7,0",
+        "8,0",
+        "8,1",
+        "6,1",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "8,4",
+        {
+          "c": "#cccccc"
+        },
+        "2,6"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "2,2",
+        "3,2",
+        "4,2",
+        "4,3",
+        "5,3",
+        "5,2",
+        "6,2",
+        "7,2",
+        "8,2",
+        "8,3",
+        "7,5",
+        {
+          "x": 1.25
+        },
+        "6,5"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "0,2",
+        "1,4",
+        "2,4",
+        "3,4",
+        "4,4",
+        "4,5",
+        "5,5",
+        "6,4",
+        "6,4",
+        "7,4",
+        "8,5",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "0,7",
+        {
+          "c": "#777777"
+        },
+        "3,5",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "0,6",
+        {
+          "w": 1.25
+        },
+        "1,5",
+        {
+          "w": 1.25
+        },
+        "2,3",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "3,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "3,6",
+        {
+          "w": 1.25
+        },
+        "3,3",
+        {
+          "x": 0.5,
+          "c": "#777777"
+        },
+        "0,3",
+        "7,3",
+        "0,5"
+      ]
+    ]
+  }
+}

--- a/v3/gmmk/gmmk2/p96/ansi/p96_ansi.json
+++ b/v3/gmmk/gmmk2/p96/ansi/p96_ansi.json
@@ -1,0 +1,181 @@
+{
+  "name": "GMMK V2 96 ANSI",
+  "vendorId": "0x320F",
+  "productId": "0x504B",
+  "keycodes": ["qmk_lighting"],
+  "menus": [{
+    "label": "Lighting",
+    "content": [{
+      "label": "Backlight",
+      "content": [{
+          "label": "Brightness",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+        },
+        {
+          "label": "Effect",
+          "type": "dropdown",
+          "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+          "options": [
+            ["NONE", 0],
+            ["SOLID_COLOR", 1],
+            ["ALPHAS_MODS", 2],
+            ["GRADIENT_UP_DOWN", 3],
+            ["GRADIENT_LEFT_RIGHT", 4],
+            ["BREATHING", 5],
+            ["BAND_SAT", 6],
+            ["BAND_VAL", 7],
+            ["BAND_PINWHEEL_SAT", 8],
+            ["BAND_PINWHEEL_VAL", 9],
+            ["BAND_SPIRAL_SAT", 10],
+            ["BAND_SPIRAL_VAL", 11],
+            ["CYCLE_ALL", 12],
+            ["CYCLE_LEFT_RIGHT", 13],
+            ["CYCLE_UP_DOWN", 14],
+            ["CYCLE_OUT_IN", 15],
+            ["CYCLE_OUT_IN_DUAL", 16],
+            ["RAINBOW_MOVING_CHEVRON", 17],
+            ["CYCLE_PINWHEEL", 18],
+            ["CYCLE_SPIRAL", 19],
+            ["DUAL_BEACON", 20],
+            ["RAINBOW_BEACON", 21],
+            ["RAINBOW_PINWHEELS", 22],
+            ["RAINDROPS", 23],
+            ["JELLYBEAN_RAINDROPS", 24],
+            ["HUE_BREATHING", 25],
+            ["HUE_PENDULUM", 26],
+            ["HUE_WAVE", 27],
+            ["PIXEL_FRACTAL", 28],
+            ["PIXEL_FLOW", 29],
+            ["PIXEL_RAIN", 30]
+          ]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} >= 3 && {id_qmk_rgb_matrix_effect} <= 4",
+          "label": "Gradiant Size",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 3 && {id_qmk_rgb_matrix_effect} != 4",
+          "label": "Effect Speed",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+          "label": "Color",
+          "type": "color",
+          "content": ["id_qmk_rgb_matrix_color", 3, 4]
+        }
+      ]
+    }]
+  }],
+  "matrix": {
+    "rows": 14,
+    "cols": 8
+  },
+  "layouts": {
+    "keymap": [
+      [{
+        "c": "#777777"
+      }, "0,0", {
+        "x": 0.25,
+        "c": "#cccccc"
+      }, "1,0", "2,0", "3,0", "4,0", {
+        "x": 0.25,
+        "c": "#777777"
+      }, "5,0", "6,0", "7,0", "8,0", {
+        "x": 0.25,
+        "c": "#cccccc"
+      }, "9,0", "10,0", "11,0", "12,0", {
+        "x": 0.25,
+        "c": "#777777"
+      }, "13,0", {
+        "x": 0.5
+      }, "0,6", "1,6", "2,6", "3,6"],
+      [{
+        "y": 0.25,
+        "c": "#cccccc"
+      }, "0,1", "1,1", "2,1", "3,1", "4,1", "5,1", "6,1", "7,1", "8,1", "9,1", "10,1", "11,1", "12,1", {
+        "c": "#aaaaaa",
+        "w": 2
+      }, "13,1", {
+        "x": 0.5,
+        "c": "#cccccc"
+      }, "4,6", "5,6", "6,6", "7,6"],
+      [{
+        "c": "#aaaaaa",
+        "w": 1.5
+      }, "0,2", {
+        "c": "#cccccc"
+      }, "1,2", "2,2", "3,2", "4,2", "5,2", "6,2", "7,2", "8,2", "9,2", "10,2", "11,2", "12,2", {
+        "w": 1.5
+      }, "13,2", {
+        "x": 0.5
+      }, "8,6", "9,6", "10,6", {
+        "h": 2
+      }, "11,6"],
+      [{
+        "c": "#aaaaaa",
+        "w": 1.75
+      }, "0,3", {
+        "c": "#cccccc"
+      }, "1,3", "2,3", "3,3", "4,3", "5,3", "6,3", "7,3", "8,3", "9,3", "10,3", "11,3", {
+        "c": "#777777",
+        "w": 2.25
+      }, "13,3", {
+        "x": 0.5,
+        "c": "#cccccc"
+      }, "10,7", "11,7", "12,7"],
+      [{
+        "c": "#aaaaaa",
+        "w": 2.25
+      }, "0,4", {
+        "c": "#cccccc"
+      }, "2,4", "3,4", "4,4", "5,4", "6,4", "7,4", "8,4", "9,4", "10,4", "11,4", {
+        "c": "#aaaaaa",
+        "w": 1.75
+      }, "13,4", {
+        "x": 0.25,
+        "y": 0.25,
+        "c": "#777777"
+      }, "1,7", {
+        "x": 0.25,
+        "y": -0.25,
+        "c": "#cccccc"
+      }, "6,7", "7,7", "8,7", {
+        "h": 2
+      }, "9,7"],
+      [{
+        "c": "#aaaaaa",
+        "w": 1.25
+      }, "0,5", {
+        "c": "#aaaaaa",
+        "w": 1.25
+      }, "1,5", {
+        "c": "#aaaaaa",
+        "w": 1.25
+      }, "2,5", {
+        "c": "#cccccc",
+        "w": 6.25
+      }, "6,5", {
+        "c": "#aaaaaa",
+        "w": 1
+      }, "9,5", "10,5", "12,5", {
+        "x": 0.25,
+        "y": 0.25,
+        "c": "#777777",
+        "w": 1
+      }, "0,7", "2,7", "3,7", {
+        "x": 0.25,
+        "y": -0.25,
+        "c": "#cccccc",
+        "w": 1
+      }, "4,7", "5,7"]
+    ]
+  }
+}

--- a/v3/gmmk/gmmk2/p96/iso/p96_iso.json
+++ b/v3/gmmk/gmmk2/p96/iso/p96_iso.json
@@ -1,0 +1,310 @@
+{
+  "name": "GMMK V2 96 ISO",
+  "vendorId": "0x320F",
+  "productId": "0x505A",
+  "keycodes": ["qmk_lighting"],
+  "menus": [{
+    "label": "Lighting",
+    "content": [{
+      "label": "Backlight",
+      "content": [{
+          "label": "Brightness",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+        },
+        {
+          "label": "Effect",
+          "type": "dropdown",
+          "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+          "options": [
+            ["NONE", 0],
+            ["SOLID_COLOR", 1],
+            ["ALPHAS_MODS", 2],
+            ["GRADIENT_UP_DOWN", 3],
+            ["GRADIENT_LEFT_RIGHT", 4],
+            ["BREATHING", 5],
+            ["BAND_SAT", 6],
+            ["BAND_VAL", 7],
+            ["BAND_PINWHEEL_SAT", 8],
+            ["BAND_PINWHEEL_VAL", 9],
+            ["BAND_SPIRAL_SAT", 10],
+            ["BAND_SPIRAL_VAL", 11],
+            ["CYCLE_ALL", 12],
+            ["CYCLE_LEFT_RIGHT", 13],
+            ["CYCLE_UP_DOWN", 14],
+            ["CYCLE_OUT_IN", 15],
+            ["CYCLE_OUT_IN_DUAL", 16],
+            ["RAINBOW_MOVING_CHEVRON", 17],
+            ["CYCLE_PINWHEEL", 18],
+            ["CYCLE_SPIRAL", 19],
+            ["DUAL_BEACON", 20],
+            ["RAINBOW_BEACON", 21],
+            ["RAINBOW_PINWHEELS", 22],
+            ["RAINDROPS", 23],
+            ["JELLYBEAN_RAINDROPS", 24],
+            ["HUE_BREATHING", 25],
+            ["HUE_PENDULUM", 26],
+            ["HUE_WAVE", 27],
+            ["PIXEL_FRACTAL", 28],
+            ["PIXEL_FLOW", 29],
+            ["PIXEL_RAIN", 30]
+          ]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} >= 3 && {id_qmk_rgb_matrix_effect} <= 4",
+          "label": "Gradiant Size",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 3 && {id_qmk_rgb_matrix_effect} != 4",
+          "label": "Effect Speed",
+          "type": "range",
+          "options": [0, 255],
+          "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+        },
+        {
+          "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+          "label": "Color",
+          "type": "color",
+          "content": ["id_qmk_rgb_matrix_color", 3, 4]
+        }
+      ]
+    }]
+  }],
+  "matrix": {
+    "rows": 14,
+    "cols": 8
+  },
+  "layouts": {
+    "keymap": [
+      [{
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "1,0",
+        "2,0",
+        "3,0",
+        "4,0",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "5,0",
+        "6,0",
+        "7,0",
+        "8,0",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "9,0",
+        "10,0",
+        "11,0",
+        "12,0",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "13,0",
+        {
+          "x": 0.5
+        },
+        "0,6",
+        "1,6",
+        "2,6",
+        "3,6"
+      ],
+      [{
+          "y": 0.25,
+          "c": "#cccccc"
+        },
+        "0,1",
+        "1,1",
+        "2,1",
+        "3,1",
+        "4,1",
+        "5,1",
+        "6,1",
+        "7,1",
+        "8,1",
+        "9,1",
+        "10,1",
+        "11,1",
+        "12,1",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "13,1",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "4,6",
+        "5,6",
+        "6,6",
+        "7,6"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "0,2",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "2,2",
+        "3,2",
+        "4,2",
+        "5,2",
+        "6,2",
+        "7,2",
+        "8,2",
+        "9,2",
+        "10,2",
+        "11,2",
+        "12,2",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "12,1",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "8,6",
+        "9,6",
+        "10,6",
+        {
+          "h": 2
+        },
+        "11,6"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "0,3",
+        {
+          "c": "#cccccc"
+        },
+        "1,3",
+        "2,3",
+        "3,3",
+        "4,3",
+        "5,3",
+        "6,3",
+        "7,3",
+        "8,3",
+        "9,3",
+        "10,3",
+        "11,3",
+        "12,3",
+        {
+          "x": 1.75
+        },
+        "10,7",
+        "11,7",
+        "12,7"
+      ],
+      [{
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "0,4",
+        {
+          "c": "#cccccc"
+        },
+        "1,4",
+        "2,4",
+        "3,4",
+        "4,4",
+        "5,4",
+        "6,4",
+        "7,4",
+        "8,4",
+        "9,4",
+        "10,4",
+        "11,4",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "13,4",
+        {
+          "x": 1.5,
+          "c": "#cccccc"
+        },
+        "6,7",
+        "7,7",
+        "8,7",
+        {
+          "h": 2
+        },
+        "9,7"
+      ],
+      [{
+          "y": -0.75,
+          "x": 14.25,
+          "c": "#777777"
+        },
+        "1,7"
+      ],
+      [{
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "0,5",
+        {
+          "w": 1.25
+        },
+        "1,5",
+        {
+          "w": 1.25
+        },
+        "2,5",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "6,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "9,5",
+        "10,5",
+        "12,5",
+        {
+          "x": 3.5,
+          "c": "#cccccc"
+        },
+        "4,7",
+        "5,7"
+      ],
+      [{
+          "y": -0.75,
+          "x": 13.25,
+          "c": "#777777"
+        },
+        "0,7",
+        "2,7",
+        "3,7"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

I have exported and modified the gmmk2 json config (v2) to match the new v3 config.
This actually tested on my gmmk2 iso latest qmk firmware with via enabled and work like a charm. I suppose the config must not be different on the other editions

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/16436 (p96)
https://github.com/qmk/qmk_firmware/pull/18185 (p65)

## Checklist

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`