### PR TITLE
add momokai tap duo

### DIFF
--- a/v3/momokai/momokai_tap_duo.json
+++ b/v3/momokai/momokai_tap_duo.json
@@ -1,0 +1,26 @@
+{
+  "name": "Momokai Tap Duo",
+  "vendorId": "0x69F9",
+  "productId": "0x0005",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgblight"],
+  "matrix": {"rows": 1, "cols": 5},
+  "layouts": {
+    "keymap": [
+      [
+        {"w": 1.5, "h": 1.5, "c": "#cccccc"},
+        "0,0",
+        {"w": 1.5, "h": 1.5, "c": "#cccccc"},
+        "0,1"
+      ],
+      [
+        {"y": 0.5, "x": 0.5, "c": "#aaaaaa"},
+        "0,2",
+        {"c": "#aaaaaa"},
+        "0,3",
+        {"c": "#aaaaaa"},
+        "0,4"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/19042
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
