### PR TITLE
Add VIA support for Keychron V8

### DIFF
--- a/src/keychron/v8/ansi.json
+++ b/src/keychron/v8/ansi.json
@@ -1,0 +1,311 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0380",
+  "lighting": {
+    "extends": "qmk_rgblight",
+    "underglowEffects": [
+      ["00. None", 0],
+      ["01. SOLID_COLOR", 1],
+      ["02. BREATHING", 1],
+      ["03. BAND_SPIRAL_VAL", 1],
+      ["04. CYCLE_ALL", 1],
+      ["05. CYCLE_LEFT_RIGHT", 1],
+      ["06. CYCLE_UP_DOWN", 1],
+      ["07. RAINBOW_MOVING_CHEVRON", 1],
+      ["08. CYCLE_OUT_IN", 1],
+      ["09. CYCLE_OUT_IN_DUAL", 1],
+      ["10. CYCLE_PINWHEEL", 1],
+      ["11. CYCLE_SPIRAL", 1],
+      ["12. DUAL_BEACON", 1],
+      ["13. RAINBOW_BEACON", 1],
+      ["14. JELLYBEAN_RAINDROPS", 1],
+      ["15. PIXEL_RAIN", 1],
+      ["16. TYPING_HEATMAP", 1],
+      ["17. DIGITAL_RAIN", 1],
+      ["18. REACTIVE_SIMPLE", 1],
+      ["19. REACTIVE_MULTIWIDE", 1],
+      ["20. REACTIVE_MULTINEXUS", 1],
+      ["21. SPLASH", 1],
+      ["22. SOLID_SPLASH", 1]
+    ]
+  },
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "x": 0.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.3
+        },
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/src/keychron/v8/ansi_encoder.json
+++ b/src/keychron/v8/ansi_encoder.json
@@ -1,0 +1,311 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0381",
+  "lighting": {
+    "extends": "qmk_rgblight",
+    "underglowEffects": [
+      ["00. None", 0],
+      ["01. SOLID_COLOR", 1],
+      ["02. BREATHING", 1],
+      ["03. BAND_SPIRAL_VAL", 1],
+      ["04. CYCLE_ALL", 1],
+      ["05. CYCLE_LEFT_RIGHT", 1],
+      ["06. CYCLE_UP_DOWN", 1],
+      ["07. RAINBOW_MOVING_CHEVRON", 1],
+      ["08. CYCLE_OUT_IN", 1],
+      ["09. CYCLE_OUT_IN_DUAL", 1],
+      ["10. CYCLE_PINWHEEL", 1],
+      ["11. CYCLE_SPIRAL", 1],
+      ["12. DUAL_BEACON", 1],
+      ["13. RAINBOW_BEACON", 1],
+      ["14. JELLYBEAN_RAINDROPS", 1],
+      ["15. PIXEL_RAIN", 1],
+      ["16. TYPING_HEATMAP", 1],
+      ["17. DIGITAL_RAIN", 1],
+      ["18. REACTIVE_SIMPLE", 1],
+      ["19. REACTIVE_MULTIWIDE", 1],
+      ["20. REACTIVE_MULTINEXUS", 1],
+      ["21. SPLASH", 1],
+      ["22. SOLID_SPLASH", 1]
+    ]
+  },
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 13.6
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "x": 0.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.3
+        },
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/src/keychron/v8/iso.json
+++ b/src/keychron/v8/iso.json
@@ -1,0 +1,316 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0382",
+  "lighting": {
+    "extends": "qmk_rgblight",
+    "underglowEffects": [
+      ["00. None", 0],
+      ["01. SOLID_COLOR", 1],
+      ["02. BREATHING", 1],
+      ["03. BAND_SPIRAL_VAL", 1],
+      ["04. CYCLE_ALL", 1],
+      ["05. CYCLE_LEFT_RIGHT", 1],
+      ["06. CYCLE_UP_DOWN", 1],
+      ["07. RAINBOW_MOVING_CHEVRON", 1],
+      ["08. CYCLE_OUT_IN", 1],
+      ["09. CYCLE_OUT_IN_DUAL", 1],
+      ["10. CYCLE_PINWHEEL", 1],
+      ["11. CYCLE_SPIRAL", 1],
+      ["12. DUAL_BEACON", 1],
+      ["13. RAINBOW_BEACON", 1],
+      ["14. JELLYBEAN_RAINDROPS", 1],
+      ["15. PIXEL_RAIN", 1],
+      ["16. TYPING_HEATMAP", 1],
+      ["17. DIGITAL_RAIN", 1],
+      ["18. REACTIVE_SIMPLE", 1],
+      ["19. REACTIVE_MULTIWIDE", 1],
+      ["20. REACTIVE_MULTINEXUS", 1],
+      ["21. SPLASH", 1],
+      ["22. SOLID_SPLASH", 1]
+    ]
+  },
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap":[
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6,
+          "c": "#cccccc"
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "x": 0.5,
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.5
+        },
+        "1,11",
+        "1,12",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 1.25
+        },
+        "3,0",
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/src/keychron/v8/iso_encoder.json
+++ b/src/keychron/v8/iso_encoder.json
@@ -1,0 +1,316 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0383",
+  "lighting": {
+    "extends": "qmk_rgblight",
+    "underglowEffects": [
+      ["00. None", 0],
+      ["01. SOLID_COLOR", 1],
+      ["02. BREATHING", 1],
+      ["03. BAND_SPIRAL_VAL", 1],
+      ["04. CYCLE_ALL", 1],
+      ["05. CYCLE_LEFT_RIGHT", 1],
+      ["06. CYCLE_UP_DOWN", 1],
+      ["07. RAINBOW_MOVING_CHEVRON", 1],
+      ["08. CYCLE_OUT_IN", 1],
+      ["09. CYCLE_OUT_IN_DUAL", 1],
+      ["10. CYCLE_PINWHEEL", 1],
+      ["11. CYCLE_SPIRAL", 1],
+      ["12. DUAL_BEACON", 1],
+      ["13. RAINBOW_BEACON", 1],
+      ["14. JELLYBEAN_RAINDROPS", 1],
+      ["15. PIXEL_RAIN", 1],
+      ["16. TYPING_HEATMAP", 1],
+      ["17. DIGITAL_RAIN", 1],
+      ["18. REACTIVE_SIMPLE", 1],
+      ["19. REACTIVE_MULTIWIDE", 1],
+      ["20. REACTIVE_MULTINEXUS", 1],
+      ["21. SPLASH", 1],
+      ["22. SOLID_SPLASH", 1]
+    ]
+  },
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap":[
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6,
+          "c": "#cccccc"
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "x": 0.5,
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.5
+        },
+        "1,11",
+        "1,12",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 1.25
+        },
+        "3,0",
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/v8/ansi.json
+++ b/v3/keychron/v8/ansi.json
@@ -1,0 +1,345 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0380",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCKE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "x": 0.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.3
+        },
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/v8/ansi_encoder.json
+++ b/v3/keychron/v8/ansi_encoder.json
@@ -1,0 +1,345 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0381",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCKE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 13.6
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "x": 0.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.3
+        },
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/v8/iso.json
+++ b/v3/keychron/v8/iso.json
@@ -1,0 +1,350 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0382",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCKE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap":[
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6,
+          "c": "#cccccc"
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "x": 0.5,
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.5
+        },
+        "1,11",
+        "1,12",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 1.25
+        },
+        "3,0",
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/v8/iso_encoder.json
+++ b/v3/keychron/v8/iso_encoder.json
@@ -1,0 +1,350 @@
+{
+  "name": "Keychron V8",
+  "vendorId": "0x3434",
+  "productId": "0x0383",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCKE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad",      "title": "Launch Pad in macOS",      "shortName": "LPad"},
+    {"name": "Left Option",     "title": "Left Option in macOS",     "shortName": "LOpt"},
+    {"name": "Right Option",    "title": "Right Option in macOS",    "shortName": "ROpt"},
+    {"name": "Left Cmd",        "title": "Left Command in macOS",    "shortName": "LCmd"},
+    {"name": "Right Cmd",       "title": "Right Command in macOS",   "shortName": "RCmd"},
+    {"name": "Siri",            "title": "Siri in macOS",            "shortName": "Siri"},
+    {"name": "Task View",       "title": "Task View in windows",     "shortName": "Task"},
+    {"name": "File Explorer",   "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot",     "title": "Screenshot in macOS",      "shortName": "SShot"},
+    {"name": "Cortana",         "title": "Cortana in windows",       "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 5, "cols": 15},
+  "layouts": {
+    "keymap":[
+      [
+        {
+          "x": 2.75
+        },
+        "0,2",
+        {
+          "x": 8.85
+        },
+        "0,11",
+        {
+          "x": 3.5,
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.85,
+          "x": 13.6,
+          "c": "#cccccc"
+        },
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "y": -1,
+          "x": 0.75,
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,1"
+      ],
+      [
+        {
+          "x": 0.5,
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        {
+          "x": 10.5
+        },
+        "1,11",
+        "1,12",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.3,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "x": 0.25,
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        {
+          "x": 9.75
+        },
+        "2,11",
+        "2,12",
+        "2,13"
+      ],
+      [
+        {
+          "y": -0.9,
+          "x": 17.5,
+          "c": "#aaaaaa"
+        },
+        "2,14"
+      ],
+      [
+        {
+          "y": -0.1,
+          "w": 1.25
+        },
+        "3,0",
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        {
+          "x": 10.15
+        },
+        "3,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.4,
+          "c": "#777777"
+        },
+        "3,14"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.4,
+          "c": "#777777"
+        },
+        "4,12",
+        "4,13",
+        "4,14"
+      ],
+      [
+        {
+          "r": 6,
+          "y": -5.7,
+          "x": 3.85,
+          "c": "#cccccc"
+        },
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6"
+      ],
+      [
+        {
+          "x": 3.35
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5"
+      ],
+      [
+        {
+          "x": 3.55
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5"
+      ],
+      [
+        {
+          "x": 3.9
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6"
+      ],
+      [
+        {
+          "x": 4,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,6"
+      ],
+      [
+        {
+          "r": -6,
+          "y": -3.2,
+          "x": 8.35,
+          "c": "#cccccc"
+        },
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10"
+      ],
+      [
+        {
+          "x": 7.9
+        },
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10"
+      ],
+      [
+        {
+          "x": 8.25
+        },
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10"
+      ],
+      [
+        {
+          "x": 7.8
+        },
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11"
+      ],
+      [
+        {
+          "x": 7.8,
+          "c": "#aaaaaa"
+        },
+        "4,7",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,9"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add VIA JSONs for Keychron V8.
Thanks!
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- Add VIA JSONs for Keychron V8.

1. Add ANSI and ISO versions, enable encoder support.
2. Add encoder ID (e0) as the center label for encoder keys to support encoder mapping.
3. Added JSONs to src and v3.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
qmk/qmk_firmware#19361
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
