### PR TITLE
Update lighting UI options for GMMK 2

### DIFF
--- a/v3/gmmk/gmmk2/p65/ansi/p65_ansi.json
+++ b/v3/gmmk/gmmk2/p65/ansi/p65_ansi.json
@@ -3,7 +3,7 @@
   "vendorId": "0x320F",
   "productId": "0x5045",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 9, "cols": 8},
   "layouts": {
     "keymap": [

--- a/v3/gmmk/gmmk2/p65/iso/p65_iso.json
+++ b/v3/gmmk/gmmk2/p65/iso/p65_iso.json
@@ -3,7 +3,7 @@
   "vendorId": "0x320F",
   "productId": "0x504A",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 9, "cols": 8},
   "layouts": {
     "keymap": [

--- a/v3/gmmk/gmmk2/p96/ansi/p96_ansi.json
+++ b/v3/gmmk/gmmk2/p96/ansi/p96_ansi.json
@@ -3,7 +3,7 @@
   "vendorId": "0x320F",
   "productId": "0x504B",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 14, "cols": 8},
   "layouts": {
     "keymap": [

--- a/v3/gmmk/gmmk2/p96/iso/p96_iso.json
+++ b/v3/gmmk/gmmk2/p96/iso/p96_iso.json
@@ -3,7 +3,7 @@
   "vendorId": "0x320F",
   "productId": "0x505A",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 14, "cols": 8},
   "layouts": {
     "keymap": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Change `qmk_rgblight` in `["menus"]`to `qmk_rgb_matrix` as GMMK 2 uses `RGB_MATRIX` lighting due to people noticing that the Lighting tab is disabled (as in it doesn't show the options to change effects and effect speed/color/brightness.)

![image](https://user-images.githubusercontent.com/100170946/209896851-63ae9035-9e35-4859-add4-676fea517974.png)

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

* https://github.com/qmk/qmk_firmware/pull/16436
* https://github.com/qmk/qmk_firmware/pull/18185

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
