### PR TITLE
Add backlight to M75S

### DIFF
--- a/v3/mode/m75/m75s.json
+++ b/v3/mode/m75/m75s.json
@@ -2,6 +2,7 @@
   "name": "Mode SeventyFive S",
   "vendorId": "0x00DE",
   "productId": "0x7583",
+  "menus": ["qmk_backlight"],
   "matrix": {"rows": 7, "cols": 16},
   "layouts": {
     "labels": [


### PR DESCRIPTION
Adds backlight lighting controls to M75S

## Description

Pretty much just adding the backlight menu.

## QMK Pull Request 

Board was already PRd into VIA, this is simply an enhancement.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
