### PR TITLE
Enable rgb matrix in deng/thirty

### DIFF
--- a/v3/deng/thirty/thirty.json
+++ b/v3/deng/thirty/thirty.json
@@ -2,12 +2,8 @@
   "name": "Thirty",
   "vendorId": "0xDE29",
   "productId": "0x7342",
-  "keycodes": [
-    "qmk_lighting"
-  ],
-  "menus": [
-    "qmk_backlight"
-  ],
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {
     "rows": 6,
     "cols": 5


### PR DESCRIPTION
## Description

The hardware only implements RGB matrix with 30 WS2812 LEDs. LED Backlight is not implemented actually.

![Thirty](https://i.imgur.com/4g2fcYOh.jpeg)

However, the firmware is configured to enable both [backlight](https://docs.qmk.fm/#/feature_backlight) and [rgb matrix](https://docs.qmk.fm/#/feature_rgb_matrix). So that in VIA v2, RGB keycodes are available to reassign.

Good to know that VIA v3 now supports QMK RGB matrix config.

## QMK Pull Request 


## Checklist


- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
