### PR TITLE
Add support for Coban Pad 3A

### DIFF
--- a/src/coban/pad3a/coban_pad_3a_hotswap.json
+++ b/src/coban/pad3a/coban_pad_3a_hotswap.json
@@ -1,0 +1,19 @@
+{
+  "keyboard_name": "Coban Pad 3A",
+  "name": "Coban Pad 3A",
+  "vendorId": "0xCB3A",
+  "productId": "0xCC3A",
+  "url": "https://cobanstationery.com",
+  "maintainer": "Coban Stationery",
+  "matrix": { "rows": 1, "cols": 3 },
+  "lighting": "none",
+  "layouts": {
+      "keymap": [
+          [
+              "0,0",
+              "0,1",
+              "0,2\n\n\n\n\n\n\n\n\ne0"
+          ]
+      ]
+  }
+}

--- a/v3/coban/pad3a/coban_pad_3a_hotswap.json
+++ b/v3/coban/pad3a/coban_pad_3a_hotswap.json
@@ -1,0 +1,18 @@
+{
+  "keyboard_name": "Coban Pad 3A",
+  "name": "Coban Pad 3A",
+  "vendorId": "0xCB3A",
+  "productId": "0xCC3A",
+  "url": "https://cobanstationery.com",
+  "maintainer": "Coban Stationery",
+  "matrix": { "rows": 1, "cols": 3 },
+  "layouts": {
+      "keymap": [
+          [
+              "0,0",
+              "0,1",
+              "0,2\n\n\n\n\n\n\n\n\ne0"
+          ]
+      ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

![Coban Pad 3A](https://i.imgur.com/0afuIuY.png)

Add new keyboard: Coban Pad 3A.
Coban Pad 3A is small macro keyboard with 2 hotswapable button and 1 EC11 rotary encoder

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

https://github.com/qmk/qmk_firmware/pull/19634

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
