### PR TITLE
Add support for Bubble75

### DIFF
--- a/v3/bubble75/hotswap/bubble75.json
+++ b/v3/bubble75/hotswap/bubble75.json
@@ -1,5 +1,5 @@
 {
- "name": "bubble75",
+ "name": "Bubble Studio Bubble75",
  "vendorId": "0x4242",
  "productId": "0x5A4C",
  "menus": [

--- a/v3/bubble75/hotswap/bubble75.json
+++ b/v3/bubble75/hotswap/bubble75.json
@@ -1,0 +1,231 @@
+{
+ "name": "bubble75",
+ "vendorId": "0x4242",
+ "productId": "0x5A4C",
+ "menus": [
+  {
+    "label": "Lighting",
+    "content": [
+      {
+        "label": "Backlight",
+        "content": [
+          {
+            "label": "Brightness",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+          },
+          {
+            "label": "Effect",
+            "type": "dropdown",
+            "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+            "options": [
+              "All Off",
+              "Solid Color",
+              "Breathing",
+              "Cycle Colors",
+              "Rainbow Left/Right",
+              "Rainbow Top/Down",
+              "Ranbow Chevron Left/Right",
+              "Rainbow Circle In",
+              "Dual Rainbow Circle In",
+              "Rainbow Pinwheel CCW",
+              "Rainbow Sprial CCW",
+              "Rainbow Rotate Wide CW",
+              "Rainbow Rotate Short CW",
+              "Christmas Lights",
+              "Typing Heatmap",
+              "Matrix",
+              "Typing Single Light",
+              "Solid Color + Alternate Typing Single Light",
+              "Typing Flash Circle",
+              "Typing Flash Circle Overlapping",
+              "Typing Flash Cross",
+              "Typing Flash Cross Overlapping",
+              "Typing Growing Cross",
+              "Typing Growing Cross Overlapping",
+              "Typing Rainbow Splash",
+              "Typing Rainbow Splash Overlapping",
+              "Typing Solid Color Splash",
+              "Typing Solid Color Splash Overlapping"
+            ]
+          },
+          {
+            "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+            "label": "Effect Speed",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+          },
+          {
+            "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+            "label": "Color",
+            "type": "color",
+            "content": ["id_qmk_rgb_matrix_color", 3, 4]
+          }
+        ]
+      }
+    ]
+  }
+],
+ "matrix": { "rows": 6, "cols": 15 },
+ "layouts": {
+   "keymap": [
+  [
+    {
+      "c": "#cccccc"
+    },
+    "0,0",
+    {
+      "x": 0.5
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    {
+      "x": 0.5
+    },
+    "0,5",
+    "0,6",
+    "0,7",
+    "0,8",
+    {
+      "x": 0.5
+    },
+    "0,9",
+    "0,10",
+    "0,11",
+    "0,12",
+    {
+      "x": 0.5
+    },
+    "0,14"
+  ],
+  [
+    {
+      "y": 0.5,
+      "c": "#cccccc"
+    },
+    "1,0",
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "w": 2
+    },
+    "1,13",
+    "1,14"
+  ],
+  [
+    {
+      "w": 1.5
+    },
+    "2,0",
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    "2,12",
+    {
+      "w": 1.5
+    },
+    "2,13",
+    "2,14"
+  ],
+  [
+    {
+      "w": 1.75
+    },
+    "3,0",
+    "3,1",
+    "3,2",
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6",
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10",
+    "3,11",
+    {
+      "w": 2.25
+    },
+    "3,12",
+    "3,14"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 2.25
+    },
+    "4,0",
+    "4,1",
+    "4,2",
+    "4,3",
+    "4,4",
+    "4,5",
+    "4,6",
+    "4,7",
+    "4,8",
+    "4,9",
+    "4,10",
+    {
+      "w": 1.75
+    },
+    "4,11",
+    "4,13",
+    "4,14"
+  ],
+  [
+    {
+      "w": 1.25
+    },
+    "5,0",
+    {
+      "w": 1.25
+    },
+    "5,1",
+    {
+      "w": 1.25
+    },
+    "5,2",
+    {
+      "c": "#aaaaaa",
+      "w": 6.25
+    },
+    "5,5",
+    {
+      "w": 1.25
+    },
+    "5,8",
+    {
+      "w": 1.25
+    },
+    "5,9",
+    {
+      "x": 0.5
+    },
+    "5,11",
+    "5,13",
+    "5,14"]
+  ]
+ }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add support for Bubble75.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

(https://github.com/qmk/qmk_firmware/pull/18863)

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
