### PR TITLE
Add VIA support for Keychron Q0 Plus

### DIFF
--- a/src/keychron/q0/rev_0131.json
+++ b/src/keychron/q0/rev_0131.json
@@ -1,0 +1,164 @@
+{
+  "name": "Keychron Q0",
+  "vendorId": "0x3434",
+  "productId": "0x0131",
+  "lighting": {
+  "extends": "qmk_rgblight",
+  "underglowEffects": [
+    ["00. None", 0],
+    ["01. SOLID_COLOR", 1],
+    ["02. BREATHING", 1],
+    ["03. BAND_SPIRAL_VAL", 1],
+    ["04. CYCLE_ALL", 1],
+    ["05. CYCLE_LEFT_RIGHT", 1],
+    ["06. CYCLE_UP_DOWN", 1],
+    ["07. RAINBOW_MOVING_CHEVRON", 1],
+    ["08. CYCLE_OUT_IN", 1],
+    ["09. CYCLE_OUT_IN_DUAL", 1],
+    ["10. CYCLE_PINWHEEL", 1],
+    ["11. CYCLE_SPIRAL", 1],
+    ["12. DUAL_BEACON", 1],
+    ["13. RAINBOW_BEACON", 1],
+    ["14. JELLYBEAN_RAINDROPS", 1],
+    ["15. PIXEL_RAIN", 1],
+    ["16. TYPING_HEATMAP", 1],
+    ["17. DIGITAL_RAIN", 1],
+    ["18. REACTIVE_SIMPLE", 1],
+    ["19. REACTIVE_MULTIWIDE", 1],
+    ["20. REACTIVE_MULTINEXUS", 1],
+    ["21. SPLASH", 1],
+    ["22. SOLID_SPLASH", 1]
+    ]
+  },
+  "customKeycodes": [
+    {
+      "name": "Mission Control",
+      "title": "Mission Control in macOS",
+      "shortName": "MCtrl"
+    },
+    {
+      "name": "Launch Pad",
+      "title": "Launch Pad in macOS",
+      "shortName": "LPad"
+    },
+    {
+      "name": "Left Option",
+      "title": "Left Option in macOS",
+      "shortName": "LOpt"
+    },
+    {
+      "name": "Right Option",
+      "title": "Right Option in macOS",
+      "shortName": "ROpt"
+    },
+    {
+      "name": "Left Cmd",
+      "title": "Left Command in macOS",
+      "shortName": "LCmd"
+    },
+    {
+      "name": "Right Cmd",
+      "title": "Right Command in macOS",
+      "shortName": "RCmd"
+    },
+    {
+      "name": "Siri",
+      "title": "Siri in macOS",
+      "shortName": "Siri"
+    },
+    {
+      "name": "Task View",
+      "title": "Task View in windows",
+      "shortName": "Task"
+    },
+    {
+      "name": "File Explorer",
+      "title": "File Explorer in windows",
+      "shortName": "File"
+    },
+    {
+      "name": "Screen Shot",
+      "title": "Screenshot in macOS",
+      "shortName": "SShot"
+    },
+    {
+      "name": "Cortana",
+      "title": "Cortana in windows",
+      "shortName": "Cortana"
+    }
+  ],
+  "matrix": {"rows": 6, "cols": 5},
+  "layouts": {
+    "keymap": [
+      [
+        "0,0\n\n\n\n\n\n\n\n\ne0",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4"
+      ],
+      [
+        {
+          "y": 0.25,
+          "c": "#cccccc"
+        },
+        "1,0",
+        {
+          "x": 0.25
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4"
+      ],
+      [
+        "2,0",
+        {
+          "x": 0.25
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        {
+          "h": 2
+        },
+        "2,4"
+      ],
+      [
+        "3,0",
+        {
+          "x": 0.25
+        },
+        "3,1",
+        "3,2",
+        "3,3"
+      ],
+      [
+        "4,0",
+        {
+          "x": 0.25
+        },
+        "4,1",
+        "4,2",
+        "4,3",
+        {
+          "h": 2
+        },
+        "4,4"
+      ],
+      [
+        "5,0",
+        {
+          "x": 0.25,
+          "w": 2
+        },
+        "5,1",
+        "5,3"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/q0/rev_0131.json
+++ b/v3/keychron/q0/rev_0131.json
@@ -1,0 +1,198 @@
+{
+  "name": "Keychron Q0",
+  "vendorId": "0x3434",
+  "productId": "0x0131",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCLE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {
+      "name": "Mission Control",
+      "title": "Mission Control in macOS",
+      "shortName": "MCtrl"
+    },
+    {
+      "name": "Launch Pad",
+      "title": "Launch Pad in macOS",
+      "shortName": "LPad"
+    },
+    {
+      "name": "Left Option",
+      "title": "Left Option in macOS",
+      "shortName": "LOpt"
+    },
+    {
+      "name": "Right Option",
+      "title": "Right Option in macOS",
+      "shortName": "ROpt"
+    },
+    {
+      "name": "Left Cmd",
+      "title": "Left Command in macOS",
+      "shortName": "LCmd"
+    },
+    {
+      "name": "Right Cmd",
+      "title": "Right Command in macOS",
+      "shortName": "RCmd"
+    },
+    {
+      "name": "Siri",
+      "title": "Siri in macOS",
+      "shortName": "Siri"
+    },
+    {
+      "name": "Task View",
+      "title": "Task View in windows",
+      "shortName": "Task"
+    },
+    {
+      "name": "File Explorer",
+      "title": "File Explorer in windows",
+      "shortName": "File"
+    },
+    {
+      "name": "Screen Shot",
+      "title": "Screenshot in macOS",
+      "shortName": "SShot"
+    },
+    {
+      "name": "Cortana",
+      "title": "Cortana in windows",
+      "shortName": "Cortana"
+    }
+  ],
+  "matrix": {"rows": 6, "cols": 5},
+  "layouts": {
+    "keymap": [
+      [
+        "0,0\n\n\n\n\n\n\n\n\ne0",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4"
+      ],
+      [
+        {
+          "y": 0.25,
+          "c": "#cccccc"
+        },
+        "1,0",
+        {
+          "x": 0.25
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4"
+      ],
+      [
+        "2,0",
+        {
+          "x": 0.25
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        {
+          "h": 2
+        },
+        "2,4"
+      ],
+      [
+        "3,0",
+        {
+          "x": 0.25
+        },
+        "3,1",
+        "3,2",
+        "3,3"
+      ],
+      [
+        "4,0",
+        {
+          "x": 0.25
+        },
+        "4,1",
+        "4,2",
+        "4,3",
+        {
+          "h": 2
+        },
+        "4,4"
+      ],
+      [
+        "5,0",
+        {
+          "x": 0.25,
+          "w": 2
+        },
+        "5,1",
+        "5,3"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
As the title.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- Add VIA JSONs for Keychron Q0 Plus.

1. Add encoder ID (e0) as the center label for encoder keys to support encoder mapping.
2. Added JSONs to src and v3.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
qmk/qmk_firmware#19547
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
