### PR TITLE
Update ansi_white.json for Keychron S1

### DIFF
--- a/v3/keychron/s1/ansi_white.json
+++ b/v3/keychron/s1/ansi_white.json
@@ -2,7 +2,7 @@
   "name": "Keychron S1",
   "vendorId": "0x3434",
   "productId": "0x0411",
-  "matrix": {"rows": 6, "cols": 15},
+  "keycodes" : ["qmk_lighting"],
   "customKeycodes": [
     {
       "name": "Mission Control",
@@ -40,6 +40,7 @@
     },
     {"name": "Cortana", "title": "Cortana in windows", "shortName": "Cortana"}
   ],
+  "matrix": {"rows": 6, "cols": 15},
   "layouts": {
     "keymap": [
       [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Update ansi_white.json for Keychron S1.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- Added "qmk_lighting" in item "keycodes" and we can find the option of light effect keycodes in the left menu bar as QMK LIGHTING.
- We got feedback from Keychron users that They could not configure backlight keys since there is not relevant option, Please assist me in fixing this issue kindly, thanks!

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

- No QMK PR since it's a VIA only issue.

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
