### PR TITLE
Add GPAD8-2R Macro Pad

### DIFF
--- a/v3/gkeyboard/gpad8_2r/gpad8_2r.json
+++ b/v3/gkeyboard/gpad8_2r/gpad8_2r.json
@@ -1,0 +1,34 @@
+{
+    "name": "GPAD8-2R",
+    "vendorId": "0x474B",
+    "productId": "0x4202",
+    "keycodes": ["qmk_lighting"],
+    "menus": ["qmk_rgb_matrix"],
+    "matrix": { "rows": 3, "cols": 4},
+    "layouts": {
+      "keymap": [
+        [
+          "0,0\n\n\n\n\n\n\n\n\ne0",
+          {
+            "x": 2
+          },
+          "0,3\n\n\n\n\n\n\n\n\ne1"
+        ],
+        [
+          {
+            "y": 0.25
+          },
+          "1,0",
+          "1,1",
+          "1,2",
+          "1,3"
+        ],
+        [
+          "2,0",
+          "2,1",
+          "2,2",
+          "2,3"
+        ]
+      ]
+    }
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
