### PR TITLE
add 0xcb tutelpad

### DIFF
--- a/src/0xcb/tutelpad/tutelpad.json
+++ b/src/0xcb/tutelpad/tutelpad.json
@@ -1,0 +1,13 @@
+{
+  "name": "TutelPad",
+  "vendorId": "0xCB00",
+  "productId": "0xF09F",
+  "lighting": "qmk_backlight_rgblight",
+  "matrix": {"rows": 2, "cols": 4},
+  "layouts": {
+    "keymap": [
+      ["0,0","0,1",{"x":1.5},"0,2","0,3"],
+      ["1,0","1,1",{"x":1.5},"1,2","1,3"]
+    ]
+  }
+}

--- a/v3/0xcb/tutelpad/tutelpad.json
+++ b/v3/0xcb/tutelpad/tutelpad.json
@@ -1,0 +1,14 @@
+{
+  "name": "TutelPad",
+  "vendorId": "0xCB00",
+  "productId": "0xF09F",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_backlight_rgblight"],
+  "matrix": {"rows": 2, "cols": 4},
+  "layouts": {
+    "keymap": [
+      ["0,0","0,1",{"x":1.5},"0,2","0,3"],
+      ["1,0","1,1",{"x":1.5},"1,2","1,3"]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Added layout for the Tutelpad macropad by 0xCB

This is a new PR compared to [PR#1740](https://github.com/the-via/keyboards/pull/1740), as I had problems with my repo.

## QMK Pull Request 

[qmk_firmware#16975](https://github.com/qmk/qmk_firmware/pull/16975)

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
