### PR TITLE
Add `RGB_MATRIX` menu for GMMK Pro

### DIFF
--- a/v3/gmmk/pro/gmmk_pro.json
+++ b/v3/gmmk/pro/gmmk_pro.json
@@ -2,6 +2,8 @@
   "name": "GMMK Pro",
   "vendorId": "0x320F",
   "productId": "0x5044",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 11, "cols": 8},
   "layouts": {
     "labels": ["ISO Enter", "Split Left Shift"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Since the GMMK Pro has every effect enabled in its [`config.h`](https://github.com/qmk/qmk_firmware/blob/master/keyboards/gmmk/pro/config.h#L50-L94) file over in `qmk:qmk_firmware`, users are commenting about the lack of the `Lighting` tab in VIA, specifically for the v3 JSON since currently, there's no option for RGB customization without these two lines:
```json
"keycodes": ["qmk_lighting"],
"menus": ["qmk_rgb_matrix"],
```
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
