### PR TITLE
fixup: remove spurious backlight feature

### DIFF
--- a/src/jacky_studio/piggy60/via.json
+++ b/src/jacky_studio/piggy60/via.json
@@ -2,7 +2,7 @@
   "name": "Piggy60",
   "vendorId": "0xA13B",
   "productId": "0x1001",
-  "lighting": "qmk_backlight_rgblight",
+  "lighting": "qmk_rgblight",
   "matrix": {
     "rows": 5,
     "cols": 15

--- a/v3/jacky_studio/piggy60/via.json
+++ b/v3/jacky_studio/piggy60/via.json
@@ -3,7 +3,7 @@
   "vendorId": "0xA13B",
   "productId": "0x1001",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_backlight_rgblight"],
+  "menus": ["qmk_rgblight"],
   "matrix": {"rows": 5, "cols": 15},
   "layouts": {
     "labels": [


### PR DESCRIPTION
## Description

This board doesn't actually support backlighting.

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/18012

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
