### PR TITLE
Fix issue with Work Louder Numpad

### DIFF
--- a/v3/work_louder/numpad.json
+++ b/v3/work_louder/numpad.json
@@ -140,16 +140,6 @@
               "content": ["id_qmk_rgb_matrix_color", 3, 4]
             }
           ]
-        },
-        {
-          "label": "Indicators",
-          "content": [
-            {
-              "label": "Brightness",
-              "type": "toggle",
-              "content": ["id_wl_indicators", 0, 1]
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
## Description

Indicator code doesn't exist for the Numpad.  And because VIA handler errors well, it kills everything. 

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/18912

This is a bugfix to the via json config. PR is irrelevant. 

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
