### PR TITLE
add mechwild/sugarglider

### DIFF
--- a/v3/mechwild/sugarglider/sugarglider.json
+++ b/v3/mechwild/sugarglider/sugarglider.json
@@ -1,0 +1,59 @@
+{
+    "name": "Sugar Glider",
+    "vendorId": "0x6D77",
+    "productId": "0x1710",
+    "customKeycodes": [
+        {"name": "Touchpad DPI+", "title": "Increase Touchpad DPI", "shortName": "DPI+"},
+        {"name": "Touchpad DPI-", "title": "Decrease Touchpad DPI", "shortName": "DPI-"},
+        {"name": "Touchpad Temp DPI", "title": "Temporary Lowest DPI", "shortName": "DPIF"},
+        {"name": "Touch Tap+", "title": "Increase Touch Tap Time", "shortName": "TAP+"},
+        {"name": "Touch Tap-", "title": "Decrease Touch Tap Time", "shortName": "TAP-"},
+        {"name": "Touch Tap On", "title": "Turn On Touch Tap", "shortName": "T_ON"},
+        {"name": "Touch Tap Off", "title": "Turn Off Touch Tap", "shortName": "T_OFF"},
+        {"name": "Touch Tap Toggle", "title": "Toggle Touch Tap", "shortName": "T_TOG"}
+    ],
+    "menus": ["qmk_rgblight"],
+    "matrix": {
+        "rows": 9,
+        "cols": 6
+    },
+    "layouts": {
+        "labels": [
+          "No Left Encoder",
+          "No Right Encoder",
+          "Middle Encoder",
+          "Bottom Encoder"
+        ],
+        "keymap": [
+            [{"x":9.75,"c":"#777777"},"8,0"],
+            [{"x":9.75},"8,1"],
+            [{"x":9.75},"8,2"],
+            [{"y":1,"x":8.25,"c":"#cccccc"},"8,5\n\n\n2,1\n\n\n\n\n\ne1",{"d":true},"8,5\n\n\n2,0\n\n\n\n\n\ne2"],
+            [{"c":"#777777"},"3,0\n\n\n0,1","3,0\n\n\n0,0\n\n\n\n\n\ne0",{"x":13.25},"7,5\n\n\n1,0\n\n\n\n\n\ne2","7,5\n\n\n1,1"],
+            [{"y":0.25,"x":7.25,"c":"#cccccc"},"3,4","7,0\n\n\n3,0","7,1"],
+            [{"x":8.25},"7,0\n\n\n3,1\n\n\n\n\n\ne3"],
+            [{"r":10,"y":-8.12,"x":3.5},"0,3"],
+            [{"y":-0.88,"x":2.5},"0,2",{"x":1},"0,4","0,5"],
+            [{"y":-0.75,"x":0.5,"c":"#777777"},"0,0",{"c":"#cccccc"},"0,1"],
+            [{"y":-0.37,"x":3.5},"1,3"],
+            [{"y":-0.88,"x":2.5},"1,2",{"x":1},"1,4","1,5"],
+            [{"y":-0.75,"x":0.5,"c":"#aaaaaa"},"1,0",{"c":"#cccccc"},"1,1"],
+            [{"y":-0.37,"x":3.5},"2,3"],
+            [{"y":-0.88,"x":2.5},"2,2",{"x":1},"2,4","2,5"],
+            [{"y":-0.75,"x":0.5,"c":"#aaaaaa"},"2,0",{"c":"#cccccc"},"2,1"],
+            [{"y":0.5,"x":6.25,"c":"#aaaaaa","h":1.5},"3,3"],
+            [{"y":-0.75,"x":4.25,"h":1.5},"3,1",{"h":1.5},"3,2"],
+            [{"r":-10,"rx":14.5,"y":4.5,"x":-4.5,"h":1.5},"7,2"],
+            [{"y":-0.75,"x":-3.5,"h":1.5},"7,3",{"h":1.5},"7,4"],
+            [{"rx":15.75,"y":0.38,"x":-3,"c":"#cccccc"},"4,2"],
+            [{"y":-0.88,"x":-5},"4,0","4,1",{"x":1},"4,3"],
+            [{"y":-0.75,"x":-1},"4,4",{"c":"#aaaaaa"},"4,5"],
+            [{"y":-0.37,"x":-3,"c":"#cccccc"},"5,2"],
+            [{"y":-0.88,"x":-5},"5,0","5,1",{"x":1},"5,3"],
+            [{"y":-0.75,"x":-1},"5,4",{"c":"#777777"},"5,5"],
+            [{"y":-0.37,"x":-3,"c":"#cccccc"},"6,2"],
+            [{"y":-0.88,"x":-5},"6,0","6,1",{"x":1},"6,3"],
+            [{"y":-0.75,"x":-1},"6,4",{"c":"#aaaaaa"},"6,5"]
+        ]
+    }
+}

--- a/v3/mechwild/sugarglider/sugarglider.json
+++ b/v3/mechwild/sugarglider/sugarglider.json
@@ -13,6 +13,7 @@
         {"name": "Touch Tap Toggle", "title": "Toggle Touch Tap", "shortName": "T_TOG"}
     ],
     "menus": ["qmk_rgblight"],
+    "keycodes": [ "qmk_lighting" ],
     "matrix": {
         "rows": 9,
         "cols": 6


### PR DESCRIPTION
## Description

VIA support for `mechwild/sugarglider` :)

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/19933

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`