### PR TITLE
Add KeyDeck8

### DIFF
--- a/v3/maverick0197/keydeck8/keydeck8.json
+++ b/v3/maverick0197/keydeck8/keydeck8.json
@@ -1,0 +1,14 @@
+{
+    "name": "KeyDeck8",
+    "vendorId": "0x4D76",
+    "productId": "0x3031",
+	"matrix": {"rows": 3,"cols": 3},
+	"layouts": {
+      "keymap":
+	[
+		["0,0","0,1\n\n\n\n\n\n\n\n\ne0","0,2"],
+		["1,0","1,1","1,2"],
+		["2,0","2,1","2,2"]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Add KeyDeck8 to VIA repo

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

[qmk/qmk_firmware/pull/20107](https://github.com/qmk/qmk_firmware/pull/20107)

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
