### PR TITLE
Add support for Geistmaschine Macropod

### DIFF
--- a/v3/geistmaschine/geistmaschine-macropod.json
+++ b/v3/geistmaschine/geistmaschine-macropod.json
@@ -1,0 +1,66 @@
+{
+  "name": "Geistmaschine Macropod",
+  "vendorId": "0x676D",
+  "productId": "0x0004",
+  "matrix": { "rows": 1, "cols": 4 },
+  "layouts": {
+    "labels": [
+      ["Configuration", "Three keys right", "Three keys left", "Standalone Encoder"]
+    ],
+    "keymap": [
+      [
+        {
+          "w": 1.75,
+          "h": 1.75
+        },
+        "0,0\n\n\n0,0\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.625,
+          "x": 2,
+          "c": "#aaaaaa"
+        },
+        "0,1\n\n\n0,0",
+        "0,2\n\n\n0,0",
+        "0,3\n\n\n0,0",
+        {
+          "w": 0.5,
+          "d": true
+        },
+        "\n\n\n0,0"
+      ],
+      [
+        {
+          "y": 1.625,
+          "x": 3.75,
+          "c": "#cccccc",
+          "w": 1.75,
+          "h": 1.75
+        },
+        "0,0\n\n\n0,1\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": -0.625,
+          "c": "#aaaaaa",
+          "w": 0.5,
+          "d": true
+        },
+        "\n\n\n0,1",
+        "0,3\n\n\n0,1",
+        "0,2\n\n\n0,1",
+        "0,1\n\n\n0,1"
+      ],
+      [
+        {
+          "y": 1.625,
+          "c": "#cccccc",
+          "w": 1.75,
+          "h": 1.75
+        },
+        "0,0\n\n\n0,2\n\n\n\n\n\ne0"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add support for Geistmaschine Macropod (v3 only, board will not be sold with older firmware)
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request 
https://github.com/qmk/qmk_firmware/pull/20116
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
