### PR TITLE
update momokai RGB mode list

### DIFF
--- a/v3/momokai/momokai_tap_duo.json
+++ b/v3/momokai/momokai_tap_duo.json
@@ -1,26 +1,108 @@
 {
-  "name": "Momokai Tap Duo",
-  "vendorId": "0x69F9",
-  "productId": "0x0005",
-  "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
-  "matrix": {"rows": 1, "cols": 5},
-  "layouts": {
-    "keymap": [
-      [
-        {"w": 1.5, "h": 1.5, "c": "#cccccc"},
-        "0,0",
-        {"w": 1.5, "h": 1.5, "c": "#cccccc"},
-        "0,1"
-      ],
-      [
-        {"y": 0.5, "x": 0.5, "c": "#aaaaaa"},
-        "0,2",
-        {"c": "#aaaaaa"},
-        "0,3",
-        {"c": "#aaaaaa"},
-        "0,4"
-      ]
-    ]
-  }
+    "name": "Momokai Tap Duo",
+    "vendorId": "0x69F9",
+    "productId": "0x0005",
+    "keycodes": ["qmk_lighting"],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  "All Off",
+                  "Solid Color",
+                  "Gradient Left/Right",
+                  "Breathing",
+                  "Band Sat.",
+                  "Band Val.",
+                  "Spiral Sat.",
+                  "Spiral Val.",
+                  "Cycle All",
+                  "Cycle Left/Right",
+                  "Cycle Up/Down",
+                  "Rainbow Moving Chevron",
+                  "Cycle Out/In",
+                  "Cycle Pinwheel",
+                  "Cycle Spiral",
+                  "Rainbow Beacon",
+                  "Raindrops",
+                  "Pixel Fractal",
+                  "Typing Heatmap",
+                  "Solid Reactive Simple",
+                  "Solid Reactive",
+                  "Solid Reactive Multi Wide",
+                  "Solid Reactive Nexus",
+                  "Solid Reactive Multi Nexus",
+                  "Spash",
+                  "Solid Splash"
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "matrix": {
+        "rows": 1,
+        "cols": 5
+    },
+    "layouts": {
+        "keymap": [
+          [
+            {
+              "w": 1.5,
+              "h": 1.5,
+              "c": "#cccccc"
+            },
+            "0,0",
+            {
+              "w": 1.5,
+              "h": 1.5,
+              "c": "#cccccc"
+            },
+            "0,1"
+          ],
+          [
+            {
+              "y": 0.5,
+              "x": 0.5,
+              "c": "#aaaaaa"
+            },
+            "0,2",
+            {
+              "c": "#aaaaaa"
+            },
+            "0,3",
+            {
+              "c": "#aaaaaa"
+            },
+            "0,4"
+          ]
+        ]
+    }
 }

--- a/v3/momokai/momokai_tap_trio.json
+++ b/v3/momokai/momokai_tap_trio.json
@@ -3,7 +3,69 @@
   "vendorId": "0x69F9",
   "productId": "0x0006",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Gradient Up/Down",
+                "Gradient Left/Right",
+                "Breathing",
+                "Band Sat.",
+                "Band Val.",
+                "Cycle All",
+                "Cycle Left/Right",
+                "Cycle Up/Down",
+                "Rainbow Moving Chevron",
+                "Cycle Out/In",
+                "Cycle Out/In Dual",
+                "Dual Beacon",
+                "Rainbow Beacon",
+                "Raindrops",
+                "Pixel Fractal",
+                "Typing Heatmap",
+                "Solid Reactive Simple",
+                "Solid Reactive",
+                "Solid Reactive Multi Wide",
+                "Solid Reactive Multi Nexus",
+                "Spash",
+                "Multi Splash",
+                "Solid Splash"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "matrix": {"rows": 1, "cols": 6},
   "layouts": {
     "keymap": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
updates the list of rgb effects present for momokai tap duo and tap trio to conform to recent QMK change
## QMK Pull Request 
https://github.com/qmk/qmk_firmware/pull/20126
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
