### PR TITLE
chore: update ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # VIA Keyboards
-![Definitions](https://github.com/the-via/keyboards/actions/workflows/yarn.yml/badge.svg)
+![Definitions](https://github.com/the-via/keyboards/actions/workflows/build.yml/badge.svg)


### PR DESCRIPTION
The badge was referencing an inexistent workflow file.