### PR TITLE
Add Churrosoft Deck-8 macropad

### DIFF
--- a/v3/churrosoft/deck8.json
+++ b/v3/churrosoft/deck8.json
@@ -1,13 +1,12 @@
 {
   "name": "Deck-8",
   "vendorId": "0xCBBC",
-  "productId": "0xC101",
+  "productId": "0xC100",
   "matrix": {"rows": 2, "cols": 4},
   "layouts": {
     "keymap": [
       [{"c":"#ffffff"},"0,0","0,1","0,2","0,3"],
       ["1,0","1,1","1,2","1,3"]
     ]
-  },
-  "menus": ["qmk_rgb_matrix"]
+  }
 }

--- a/v3/churrosoft/deck8_rgb.json
+++ b/v3/churrosoft/deck8_rgb.json
@@ -1,0 +1,13 @@
+{
+  "name": "Deck-8",
+  "vendorId": "0xCBBC",
+  "productId": "0xC100",
+  "matrix": {"rows": 2, "cols": 4},
+  "layouts": {
+    "keymap": [
+      [{"c":"#ffffff"},"0,0","0,1","0,2","0,3"],
+      ["1,0","1,1","1,2","1,3"]
+    ]
+  },
+  "menus": ["qmk_rgb_matrix"]
+}

--- a/v3/churrosoft/deck8_rgb.json
+++ b/v3/churrosoft/deck8_rgb.json
@@ -9,5 +9,6 @@
       ["1,0","1,1","1,2","1,3"]
     ]
   },
-  "menus": ["qmk_rgb_matrix"]
+  "menus": ["qmk_rgb_matrix"],
+  "keycodes": [ "qmk_lighting" ]
 }

--- a/v3/churrosoft/deck8_rgb.json
+++ b/v3/churrosoft/deck8_rgb.json
@@ -1,5 +1,5 @@
 {
-  "name": "Deck-8",
+  "name": "Deck-8 RGB",
   "vendorId": "0xCBBC",
   "productId": "0xC101",
   "matrix": {"rows": 2, "cols": 4},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add Churrosoft's Deck-8 macropad.

## QMK Pull Request 

qmk/qmk_firmware#21119

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
