### PR TITLE
 boardsource equals added

### DIFF
--- a/v3/boardsource/equals/equals.json
+++ b/v3/boardsource/equals/equals.json
@@ -1,0 +1,453 @@
+{
+  "name": "Boardsource Equals",
+  "vendorId": "0x4273",
+  "productId": "0x7688",
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    "qmk_audio",
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_qmk_rgb_matrix_brightness",
+                3,
+                1
+              ]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": [
+                "id_qmk_rgb_matrix_effect",
+                3,
+                2
+              ],
+              "options": [
+                [
+                  "None",
+                  0
+                ],
+                [
+                  "Solid Color",
+                  1
+                ],
+                [
+                  "Alpha Mods",
+                  2
+                ],
+                [
+                  "Gradient Up Down",
+                  3
+                ],
+                [
+                  "Gradient Left Right",
+                  4
+                ],
+                [
+                  "Breathing",
+                  5
+                ],
+                [
+                  "Band Sat",
+                  6
+                ],
+                [
+                  "Band Val",
+                  7
+                ],
+                [
+                  "Band PinWheel Sat",
+                  8
+                ],
+                [
+                  "Band PinWheel Val",
+                  9
+                ],
+                [
+                  "Ban Spiral Sat",
+                  10
+                ],
+                [
+                  "Ban Spiral Val",
+                  11
+                ],
+                [
+                  "Cycle All",
+                  12
+                ],
+                [
+                  "Cycle Left Right",
+                  13
+                ],
+                [
+                  "Cycle Up Down",
+                  14
+                ],
+                [
+                  "Rainbow Moving Chevron",
+                  15
+                ],
+                [
+                  "Cycle Out In",
+                  16
+                ],
+                [
+                  "Cycle Out In Dual",
+                  17
+                ],
+                [
+                  "Cycle Pinwheel",
+                  18
+                ],
+                [
+                  "Cycle Spiral",
+                  19
+                ],
+                [
+                  "Dual Beacon",
+                  20
+                ],
+                [
+                  "Rainbow Beacon",
+                  21
+                ],
+                [
+                  "Rainbow Pinwheels",
+                  22
+                ],
+                [
+                  "Raindrops",
+                  23
+                ],
+                [
+                  "Jellybeans Raindrops",
+                  24
+                ],
+                [
+                  "Hue Breathing",
+                  25
+                ],
+                [
+                  "Hue Pendulum",
+                  26
+                ],
+                [
+                  "Hue Wave",
+                  27
+                ],
+                [
+                  "Pixel Rain",
+                  28
+                ],
+                [
+                  "Pixel Flow",
+                  29
+                ],
+                [
+                  "Pixel Fractal",
+                  30
+                ],
+                [
+                  "Typing Heatmap",
+                  31
+                ],
+                [
+                  "Digital Rain",
+                  32
+                ],
+                [
+                  "Solid Reactive Simple",
+                  33
+                ],
+                [
+                  "Solid Reactive",
+                  34
+                ],
+                [
+                  "Solid Reactive Wide",
+                  35
+                ],
+                [
+                  "Solid Reactive MultiWide",
+                  36
+                ],
+                [
+                  "Solid Reactive Cross",
+                  37
+                ],
+                [
+                  "Solid Reactive MultiCross",
+                  38
+                ],
+                [
+                  "Solid Reactive Nexus",
+                  39
+                ],
+                [
+                  "Solid Reactive MultiNexus",
+                  40
+                ],
+                [
+                  "Splash",
+                  41
+                ],
+                [
+                  "MultiSplash",
+                  42
+                ],
+                [
+                  "Solid Splash",
+                  43
+                ],
+                [
+                  "Solid MultiSplash",
+                  44
+                ]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_qmk_rgb_matrix_effect_speed",
+                3,
+                3
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": [
+                "id_qmk_rgb_matrix_color",
+                3,
+                4
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "matrix": {
+    "rows": 5,
+    "cols": 12
+  },
+  "layouts": {
+    "labels": [
+      "2U Space 4x12",
+      [
+        "Bottom Row",
+        "All 1U",
+        "2U Space",
+        "4x12"
+      ]
+    ],
+    "keymap": [
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,11"
+      ],
+      [
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        {
+          "c": "#aaaaaa"
+        },
+        "1,11"
+      ],
+      [
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        {
+          "c": "#aaaaaa"
+        },
+        "2,11"
+      ],
+      [
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5\n\n\n0,0",
+        "3,6\n\n\n0,0",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        {
+          "c": "#777777"
+        },
+        "3,11"
+      ],
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "4,0\n\n\n1,0",
+        "4,1\n\n\n1,0",
+        "4,2\n\n\n1,0",
+        "4,3\n\n\n1,0",
+        "4,4\n\n\n1,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,5\n\n\n1,0",
+        "4,6\n\n\n1,0",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,7\n\n\n1,0",
+        "4,8\n\n\n1,0",
+        "4,9\n\n\n1,0",
+        "4,10\n\n\n1,0",
+        "4,11\n\n\n1,0"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 5,
+          "c": "#cccccc",
+          "w": 2
+        },
+        "3,5\n\n\n0,1"
+      ],
+      [
+        {
+          "y": 0.25,
+          "c": "#aaaaaa"
+        },
+        "4,0\n\n\n1,1",
+        "4,1\n\n\n1,1",
+        "4,2\n\n\n1,1",
+        "4,3\n\n\n1,1",
+        "4,4\n\n\n1,1",
+        {
+          "c": "#cccccc",
+          "w": 2
+        },
+        "4,5\n\n\n1,1",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,7\n\n\n1,1",
+        "4,8\n\n\n1,1",
+        "4,9\n\n\n1,1",
+        "4,10\n\n\n1,1",
+        "4,11\n\n\n1,1"
+      ],
+      [
+        {
+          "c": "#cccccc",
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "w": 2,
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2",
+        {
+          "d": true
+        },
+        "\n\n\n1,2"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added a new keyboard to the boardsource folder.
it is called the equals 60 or equals 48 just a 5x12 with a snap off bottom row. 
<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/21230

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
