### PR TITLE
added qmk_lighting keycodes to jabberwocky v2

### DIFF
--- a/v3/nopunin10did/jabberwocky/v2/jabberwocky_v2.json
+++ b/v3/nopunin10did/jabberwocky/v2/jabberwocky_v2.json
@@ -2,6 +2,7 @@
   "name": "Jabberwocky v2",
   "vendorId": "0x4E50",
   "productId": "0x4A58",
+  "keycodes": ["qmk_lighting"],
   "menus": ["qmk_backlight"],
   "matrix": {
     "rows": 12,


### PR DESCRIPTION
## Description

Just adding the qmk_lighting keycodes

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->
https://github.com/qmk/qmk_firmware/pull/19014
<!--- Add link to QMK Pull Request here. -->


## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
