### PR TITLE
Added VIA support for Keychron Q11 ISO Version

### DIFF
--- a/v3/keychron/q11/iso_encoder.json
+++ b/v3/keychron/q11/iso_encoder.json
@@ -1,0 +1,317 @@
+{
+  "name": "Keychron Q11 ISO Knob",
+  "vendorId": "0x3434",
+  "productId": "0x01E1",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCLE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "LOpt"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "ROpt"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "LCmd"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "RCmd"},
+    {"name": "Siri", "title": "Siri in macOS", "shortName": "Siri"},
+    {"name": "Task View", "title": "Task View in windows", "shortName": "Task"},
+    {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot", "title": "Screenshot in macOS", "shortName": "SShot"},
+    {"name": "Cortana", "title": "Cortana in windows", "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 12, "cols": 9},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "0,0\n\n\n\n\n\n\n\n\ne0",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "0,1\nESC",
+        {
+          "c": "#cccccc"
+        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,6",
+        "0,7",
+        {
+          "x": 0.75
+        },
+        "6,0",
+        "6,1",
+        {
+          "c": "#cccccc"
+        },
+        "6,2",
+        "6,3",
+        "6,4",
+        "6,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "6,6",
+        "6,7",
+        {
+          "x": 0.25
+        },
+        "6,8\n\n\n\n\n\n\n\n\ne1"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "x": 0.25
+        },
+        "1,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        {
+          "x": 0.75
+        },
+        "7,0",
+        "7,1",
+        "7,2",
+        "7,3",
+        "7,4",
+        "7,5",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "7,6",
+        {
+          "x": 0.25
+        },
+        "7,8"
+      ],
+      [
+        "2,0",
+        {
+          "x": 0.25,
+          "w": 1.5
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,6",
+        "2,7",
+        {
+          "x": 0.75
+        },
+        "8,0",
+        "8,1",
+        "8,2",
+        "8,3",
+        "8,4",
+        "8,5",
+        "8,6",
+        {
+          "x": 0.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "8,7",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "8,8"
+      ],
+      [
+        "3,0",
+        {
+          "x": 0.25,
+          "w": 1.75
+        },
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        {
+          "x": 0.75
+        },
+        "9,0",
+        "9,1",
+        "9,2",
+        "9,3",
+        "9,4",
+        "9,5",
+        {
+          "c": "#aaaaaa"
+        },
+        "9,7",
+        {
+          "x": 1.5
+        },
+        "9,8"
+      ],
+      [
+        "4,0",
+        {
+          "x": 0.25,
+          "w": 1.25
+        },
+        "4,1",
+        "4,2",
+        {
+          "c": "#cccccc"
+        },
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        {
+          "x": 0.75
+        },
+        "10,0",
+        "10,1",
+        "10,2",
+        "10,3",
+        "10,4",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "10,5",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "10,7"
+      ],
+      [
+        {
+          "c": "#aaaaaa"
+        },
+        "5,0",
+        {
+          "x": 0.25,
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "w": 1.25
+        },
+        "5,3",
+        {
+          "w": 1.25
+        },
+        "5,4",
+        {
+          "w": 2.25
+        },
+        "5,6",
+        {
+          "x": 0.75,
+          "w": 2.75
+        },
+        "11,1",
+        "11,2",
+        "11,3",
+        "11,4",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "11,6",
+        "11,7",
+        "11,8"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Added VIA support for Keychron Q11 ISO version and request for a review, thanks!
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
- Added iso_encoder.json into v3/keychron/q11.
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
qmk/qmk_firmware#21438
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
