### PR TITLE
Add VIA support for dp3000 macropad

### DIFF
--- a/v3/dp3000/dp3000.json
+++ b/v3/dp3000/dp3000.json
@@ -1,0 +1,104 @@
+ {
+    "name": "dp3000",
+    "vendorId": "0x4450",
+    "productId": "0x6470",
+    "matrix": {"rows": 3, "cols": 4},
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 180],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  "All Off",
+                  "Solid Color",
+                  "Alphas Mods",
+                  "Gradient Up/Down",
+                  "Gradient Left/Right",
+                  "Breathing",
+                  "Band Sat.",
+                  "Band Val.",
+                  "Pinwheel Sat.",
+                  "Pinwheel Val.",
+                  "Spiral Sat.",
+                  "Spiral Val.",
+                  "Cycle All",
+                  "Cycle Left/Right",
+                  "Cycle Up/Down",
+                  "Rainbow Moving Chevron",
+                  "Cycle Pinwheel",
+                  "Cycle Spiral",
+                  "Raindrops",
+                  "Hue Breathing",
+                  "Hue Pendulum",
+                  "Hue Wave",
+                  "Typing Heatmap",
+                  "Solid Reactive Simple",
+                  "Solid Reactive",
+                  "Solid Reactive Multi Nexus",
+                  "Spash",
+                  "Solid Splash"
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "layouts": {
+      "keymap": [
+        [
+          {
+            "c":"#aaaaaa"
+          },
+          "0,0\n\n\n\n\n\n\n\n\ne0",
+          {
+            "x": 2
+          },
+          "0,3\n\n\n\n\n\n\n\n\ne1"
+        ],
+        [
+          {
+            "y": 0.5
+          },
+          {
+            "c":"#cccccc"
+          },
+          "1,0",
+          "1,1",
+          "1,2",
+          "1,3"
+        ],
+        [
+          "2,0",
+          "2,1",
+          "2,2",
+          "2,3"
+        ]
+      ]
+   }
+ }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add dp3000 macropad
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/21413

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
