### PR TITLE
Create 1upOcarina.json

### DIFF
--- a/v3/1upkeyboards/1upOcarina/1upOcarina.json
+++ b/v3/1upkeyboards/1upOcarina/1upOcarina.json
@@ -1,0 +1,118 @@
+{
+  "name": "1upocarina",
+  "vendorId": "0x6F75",
+  "productId": "0x5607",
+  "matrix": {"rows": 1, "cols": 5},
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Gradient Left/Right",
+                "Breathing",
+                "Band Sat.",
+                "Band Val.",
+                "Pinwheel Sat.",
+                "Pinwheel Val.",
+                "Spiral Sat.",
+                "Spiral Val.",
+                "Cycle All",
+                "Cycle Left/Right",
+                "Cycle Up/Down",
+                "Rainbow Moving Chevron",
+                "Cycle Out/In",
+                "Cycle Out/In Dual",
+                "Cycle Pinwheel",
+                "Cycle Spiral",
+                "Dual Beacon",
+                "Rainbow Beacon",
+                "Rainbow Pinwheels",
+                "Raindrops",
+                "Jellybean Raindrops",
+                "Hue Breathing",
+                "Hue Pendulum",
+                "Hue Wave",
+                "Heatmap",
+                "Solid Reactive Simple",
+                "Solid Reactive",
+                "Solid Reactive Wide",
+                "Solid Reactive Multiwide",
+                "Solid Reactive Cross",
+                "Solid Reactive Multicross",
+                "Solid Reactive Nexus",
+                "Solid Reactive Multinexus",
+                "Splash",
+                "Multisplash",
+                "Solid Splash",
+                "Solid Multisplash"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 1 && {id_qmk_rgb_matrix_effect} != 2",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} == 2",
+              "label": "Gradient Range",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 23 && {id_qmk_rgb_matrix_effect} != 27 && {id_qmk_rgb_matrix_effect} != 28",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Encoder"
+    ],
+    "keymap": [
+      [
+        "0,0",
+        "0,1",
+        {
+          "x": 1.5
+        },
+        "0,3",
+        "0,4"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 2.25
+        },
+        "0,2\n\n\n0,0",
+        {
+          "x": 2.5
+        },
+        "0,2\n\n\n0,1\n\n\n\n\n\ne0"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Added configuration for the ocarina from 1upkeyboards

## Description

Adding the configuration for the ocarina, a keyboard designed to play osu, but it can also just be a very very bright 5 button macropad. It has hotswap capabilities, in-switch rgb lighting, and 90 degree leds for underglow. There is also an option to add an encoder which is in the layouts options in the via configuration.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/21039

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
