### PR TITLE
Add support for Mode M256W-S and M256W-H

### DIFF
--- a/v3/mode/m256w/m256wh.json
+++ b/v3/mode/m256w/m256wh.json
@@ -1,0 +1,278 @@
+{
+   "name": "Mode M256W-H Alpha",
+   "vendorId": "0x00DE",
+   "productId": "0x5754",
+   "matrix": {"rows": 6, "cols": 16},
+   "menus": [
+  {
+    "label": "Lighting",
+    "content": [
+      {
+        "label": "Underglow",
+        "content": [
+          {
+            "label": "Brightness",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgblight_brightness", 2, 1]
+          },
+          {
+            "label": "Effect",
+            "type": "dropdown",
+            "content": ["id_qmk_rgblight_effect", 2, 2],
+            "options": [
+              "All Off",
+              "Solid Color",
+              "Breathing 1",
+              "Breathing 2",
+              "Breathing 3",
+              "Breathing 4",
+              "Rainbow Mood 1",
+              "Rainbow Mood 2",
+              "Rainbow Mood 3",
+              "Rainbow Swirl 1",
+              "Rainbow Swirl 2",
+              "Rainbow Swirl 3",
+              "Rainbow Swirl 4",
+              "Rainbow Swirl 5",
+              "Rainbow Swirl 6",
+              "Snake 1",
+              "Snake 2",
+              "Snake 3",
+              "Snake 4",
+              "Snake 5",
+              "Snake 6",
+              "Knight 1",
+              "Knight 2",
+              "Knight 3",
+              "Christmas",
+              "Gradient 1",
+              "Gradient 2",
+              "Gradient 3",
+              "Gradient 4",
+              "Gradient 5",
+              "Gradient 6",
+              "Gradient 7",
+              "Gradient 8",
+              "Gradient 9",
+              "Gradient 10",
+              "RGB Test",
+              "Alternating",
+              "Twinkle 1",
+              "Twinkle 2",
+              "Twinkle 3",
+              "Twinkle 4",
+              "Twinkle 5",
+              "Twinkle 6"
+            ]
+          },
+          {
+            "showIf": "{id_qmk_rgblight_effect} != 0",
+            "label": "Effect Speed",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgblight_effect_speed", 2, 3]
+          },
+          {
+            "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
+            "label": "Color",
+            "type": "color",
+            "content": ["id_qmk_rgblight_color", 2, 4]
+          },
+          {
+          "label": "Second RGB row",
+          "type": "toggle",
+          "content": ["id_is_second_rgb_row_active", 0, 0]
+          }
+      ]
+    }
+    ]
+  }
+],
+   "keycodes": ["qmk_lighting"],
+   "layouts": {
+       "labels": ["7U bottom row"],
+       "keymap":
+[
+  [
+    {
+      "c": "#777777"
+    },
+    "0,0",
+    {
+      "c": "#cccccc"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    "0,5",
+    "0,6",
+    "0,7",
+    "0,8",
+    "0,9",
+    "0,10",
+    "0,11",
+    "0,12",
+    {
+      "c": "#aaaaaa",
+      "w": 2
+    },
+    "0,13",
+    {
+      "c": "#cccccc"
+    },
+    "0,14"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "1,0",
+    {
+      "c": "#cccccc"
+    },
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "w": 1.5
+    },
+    "1,13",
+    "1,14"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "2,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    {
+      "c": "#777777",
+      "w": 2.25
+    },
+    "2,13",
+    {
+      "c": "#cccccc"
+    },
+    "2,14"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 2.25
+    },
+    "3,0",
+    {
+      "c": "#cccccc"
+    },
+    "3,2",
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6",
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10",
+    "3,11",
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "3,12",
+    {
+      "c": "#777777"
+    },
+    "3,13",
+    {
+      "c": "#cccccc"
+    },
+    "3,14"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "5,0\n\n\n0,0",
+    {
+      "w": 1.25
+    },
+    "5,1\n\n\n0,0",
+    {
+      "w": 1.25
+    },
+    "5,2\n\n\n0,0",
+    {
+      "c": "#cccccc",
+      "w": 6.25
+    },
+    "5,15\n\n\n0,0",
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,9\n\n\n0,0",
+    {
+      "w": 1.25
+    },
+    "4,10\n\n\n0,0",
+    {
+      "x": 0.5,
+      "c": "#777777"
+    },
+    "4,11",
+    "4,12",
+    "4,13"
+  ],
+  [
+    {
+      "y": 0.25,
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "5,0\n\n\n0,1",
+    "5,1\n\n\n0,1",
+    {
+      "w": 1.5
+    },
+    "5,2\n\n\n0,1",
+    {
+      "c": "#cccccc",
+      "w": 7
+    },
+    "5,15\n\n\n0,1",
+    {
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "4,10\n\n\n0,1"
+  ]
+]
+}
+}

--- a/v3/mode/m256w/m256ws.json
+++ b/v3/mode/m256w/m256ws.json
@@ -1,0 +1,310 @@
+{
+   "name": "Mode M256W-S Alpha",
+   "vendorId": "0x00DE",
+   "productId": "0x5753",
+   "matrix": {"rows": 6, "cols": 15},
+   "menus": [
+  {
+    "label": "Lighting",
+    "content": [
+      {
+        "label": "Underglow",
+        "content": [
+          {
+            "label": "Brightness",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgblight_brightness", 2, 1]
+          },
+          {
+            "label": "Effect",
+            "type": "dropdown",
+            "content": ["id_qmk_rgblight_effect", 2, 2],
+            "options": [
+              "All Off",
+              "Solid Color",
+              "Breathing 1",
+              "Breathing 2",
+              "Breathing 3",
+              "Breathing 4",
+              "Rainbow Mood 1",
+              "Rainbow Mood 2",
+              "Rainbow Mood 3",
+              "Rainbow Swirl 1",
+              "Rainbow Swirl 2",
+              "Rainbow Swirl 3",
+              "Rainbow Swirl 4",
+              "Rainbow Swirl 5",
+              "Rainbow Swirl 6",
+              "Snake 1",
+              "Snake 2",
+              "Snake 3",
+              "Snake 4",
+              "Snake 5",
+              "Snake 6",
+              "Knight 1",
+              "Knight 2",
+              "Knight 3",
+              "Christmas",
+              "Gradient 1",
+              "Gradient 2",
+              "Gradient 3",
+              "Gradient 4",
+              "Gradient 5",
+              "Gradient 6",
+              "Gradient 7",
+              "Gradient 8",
+              "Gradient 9",
+              "Gradient 10",
+              "RGB Test",
+              "Alternating",
+              "Twinkle 1",
+              "Twinkle 2",
+              "Twinkle 3",
+              "Twinkle 4",
+              "Twinkle 5",
+              "Twinkle 6"
+            ]
+          },
+          {
+            "showIf": "{id_qmk_rgblight_effect} != 0",
+            "label": "Effect Speed",
+            "type": "range",
+            "options": [0, 255],
+            "content": ["id_qmk_rgblight_effect_speed", 2, 3]
+          },
+          {
+            "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
+            "label": "Color",
+            "type": "color",
+            "content": ["id_qmk_rgblight_color", 2, 4]
+          },
+          {
+          "label": "Second RGB row",
+          "type": "toggle",
+          "content": ["id_is_second_rgb_row_active", 0, 0]
+          }
+      ]
+    }
+    ]
+  }
+],
+   "keycodes": ["qmk_lighting"],
+   "layouts": {
+       "labels": ["Split Backspace", "ISO Enter", "Split LShift", "7U bottom row"],
+       "keymap": [
+  [
+    {
+      "x": 15.5
+    },
+    "0,13\n\n\n0,1",
+    "0,14\n\n\n0,1"
+  ],
+  [
+    {
+      "y": 0.25,
+      "x": 2.5,
+      "c": "#777777"
+    },
+    "0,0",
+    {
+      "c": "#cccccc"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    "0,5",
+    "0,6",
+    "0,7",
+    "0,8",
+    "0,9",
+    "0,10",
+    "0,11",
+    "0,12",
+    {
+      "c": "#aaaaaa",
+      "w": 2
+    },
+    "0,13\n\n\n0,0",
+    {
+      "c": "#cccccc"
+    },
+    "1,14"
+  ],
+  [
+    {
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "1,0",
+    {
+      "c": "#cccccc"
+    },
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "w": 1.5
+    },
+    "1,13\n\n\n1,0",
+    "4,14",
+    {
+      "x": 1.25,
+      "c": "#777777",
+      "w": 1.25,
+      "h": 2,
+      "w2": 1.5,
+      "h2": 1,
+      "x2": -0.25
+    },
+    "2,13\n\n\n1,1"
+  ],
+  [
+    {
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "5,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    {
+      "c": "#777777",
+      "w": 2.25
+    },
+    "2,13\n\n\n1,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,14",
+    {
+      "x": 0.25
+    },
+    "2,12\n\n\n1,1"
+  ],
+  [
+    {
+      "w": 1.25
+    },
+    "3,0\n\n\n2,1",
+    "3,1\n\n\n2,1",
+    {
+      "x": 0.25,
+      "c": "#aaaaaa",
+      "w": 2.25
+    },
+    "3,0\n\n\n2,0",
+    {
+      "c": "#cccccc"
+    },
+    "3,2",
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6",
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10",
+    "3,11",
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "3,12",
+    {
+      "c": "#777777"
+    },
+    "3,13",
+    {
+      "c": "#cccccc"
+    },
+    "3,14"
+  ],
+  [
+    {
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,0\n\n\n3,0",
+    {
+      "w": 1.25
+    },
+    "4,1\n\n\n3,0",
+    {
+      "w": 1.25
+    },
+    "4,2\n\n\n3,0",
+    {
+      "c": "#cccccc",
+      "w": 6.25
+    },
+    "4,6\n\n\n3,0",
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,9\n\n\n3,0",
+    {
+      "w": 1.25
+    },
+    "4,10\n\n\n3,0",
+    {
+      "x": 0.5,
+      "c": "#777777"
+    },
+    "4,11",
+    "4,12",
+    "4,13"
+  ],
+  [
+    {
+      "y": 0.25,
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "4,0\n\n\n3,1",
+    "4,1\n\n\n3,1",
+    {
+      "w": 1.5
+    },
+    "4,2\n\n\n3,1",
+    {
+      "c": "#cccccc",
+      "w": 7
+    },
+    "4,6\n\n\n3,1",
+    {
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "4,10\n\n\n3,1"
+  ]
+]
+}
+}


### PR DESCRIPTION


## Description

Adds support for Mode M256W-S and M256W-H

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/20502

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
