### PR TITLE
Remove Mission Control and Launchpad from Keychron boards

### DIFF
--- a/v3/keychron/q10/ansi_encoder.json
+++ b/v3/keychron/q10/ansi_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q10/iso_encoder.json
+++ b/v3/keychron/q10/iso_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/ansi.json
+++ b/v3/keychron/q3/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/ansi_encoder.json
+++ b/v3/keychron/q3/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/iso.json
+++ b/v3/keychron/q3/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/iso_encoder.json
+++ b/v3/keychron/q3/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/jis.json
+++ b/v3/keychron/q3/jis.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q3/jis_encoder.json
+++ b/v3/keychron/q3/jis_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q4/ansi.json
+++ b/v3/keychron/q4/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 14},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q5/ansi.json
+++ b/v3/keychron/q5/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q5/ansi_encoder.json
+++ b/v3/keychron/q5/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q5/iso.json
+++ b/v3/keychron/q5/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q5/iso_encoder.json
+++ b/v3/keychron/q5/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q6/ansi.json
+++ b/v3/keychron/q6/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 20},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q6/ansi_encoder.json
+++ b/v3/keychron/q6/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 20},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q6/iso.json
+++ b/v3/keychron/q6/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 20},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q6/iso_encoder.json
+++ b/v3/keychron/q6/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 20},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q60/ansi.json
+++ b/v3/keychron/q60/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 14},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q65/ansi_encoder.json
+++ b/v3/keychron/q65/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q7/ansi.json
+++ b/v3/keychron/q7/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q7/iso.json
+++ b/v3/keychron/q7/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q8/ansi.json
+++ b/v3/keychron/q8/ansi.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q8/ansi_encoder.json
+++ b/v3/keychron/q8/ansi_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q8/iso.json
+++ b/v3/keychron/q8/iso.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q8/iso_encoder.json
+++ b/v3/keychron/q8/iso_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q9/ansi.json
+++ b/v3/keychron/q9/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 4, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q9/ansi_encoder.json
+++ b/v3/keychron/q9/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 4, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q9/iso.json
+++ b/v3/keychron/q9/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 4, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/q9/iso_encoder.json
+++ b/v3/keychron/q9/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 4, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/s1/ansi_rgb.json
+++ b/v3/keychron/s1/ansi_rgb.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/s1/ansi_white.json
+++ b/v3/keychron/s1/ansi_white.json
@@ -5,12 +5,6 @@
   "keycodes" : ["qmk_lighting"],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/ansi.json
+++ b/v3/keychron/v1/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/ansi_encoder.json
+++ b/v3/keychron/v1/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/iso.json
+++ b/v3/keychron/v1/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/iso_encoder.json
+++ b/v3/keychron/v1/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/jis.json
+++ b/v3/keychron/v1/jis.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v1/jis_encoder.json
+++ b/v3/keychron/v1/jis_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v10/ansi_encoder.json
+++ b/v3/keychron/v10/ansi_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v10/iso_encoder.json
+++ b/v3/keychron/v10/iso_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/ansi.json
+++ b/v3/keychron/v2/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/ansi_encoder.json
+++ b/v3/keychron/v2/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/iso.json
+++ b/v3/keychron/v2/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/iso_encoder.json
+++ b/v3/keychron/v2/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/jis.json
+++ b/v3/keychron/v2/jis.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v2/jis_encoder.json
+++ b/v3/keychron/v2/jis_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 15},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/ansi.json
+++ b/v3/keychron/v3/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/ansi_encoder.json
+++ b/v3/keychron/v3/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/iso.json
+++ b/v3/keychron/v3/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/iso_encoder.json
+++ b/v3/keychron/v3/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/jis.json
+++ b/v3/keychron/v3/jis.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v3/jis_encoder.json
+++ b/v3/keychron/v3/jis_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v4/ansi.json
+++ b/v3/keychron/v4/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 14},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v4/iso.json
+++ b/v3/keychron/v4/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 14},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v5/ansi.json
+++ b/v3/keychron/v5/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v5/ansi_encoder.json
+++ b/v3/keychron/v5/ansi_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v5/iso.json
+++ b/v3/keychron/v5/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v5/iso_encoder.json
+++ b/v3/keychron/v5/iso_encoder.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 6, "cols": 18},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v6/ansi.json
+++ b/v3/keychron/v6/ansi.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v6/ansi_encoder.json
+++ b/v3/keychron/v6/ansi_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v6/iso.json
+++ b/v3/keychron/v6/iso.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v6/iso_encoder.json
+++ b/v3/keychron/v6/iso_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v7/ansi.json
+++ b/v3/keychron/v7/ansi.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v7/iso.json
+++ b/v3/keychron/v7/iso.json
@@ -67,12 +67,6 @@
   "matrix": {"rows": 5, "cols": 16},
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v8/ansi.json
+++ b/v3/keychron/v8/ansi.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v8/ansi_encoder.json
+++ b/v3/keychron/v8/ansi_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v8/iso.json
+++ b/v3/keychron/v8/iso.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"

--- a/v3/keychron/v8/iso_encoder.json
+++ b/v3/keychron/v8/iso_encoder.json
@@ -66,12 +66,6 @@
   ],
   "customKeycodes": [
     {
-      "name": "Mission Control",
-      "title": "Mission Control in macOS",
-      "shortName": "MCtrl"
-    },
-    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
-    {
       "name": "Left Option",
       "title": "Left Option in macOS",
       "shortName": "LOpt"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Since the keycodes, `MISSION_CONTROL` and `LAUNCHPAD` are now moved into core over in `qmk/qmk_firmware`, there's no need to keep them inside the v3 JSONs. 

## QMK Pull Request 

* https://github.com/qmk/qmk_firmware/pull/19884

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
