### PR TITLE
Add tps40 KeyBoard

### DIFF
--- a/v3/ubest/tps40/tps40a.json
+++ b/v3/ubest/tps40/tps40a.json
@@ -1,0 +1,123 @@
+{
+	"name": "tps40a",
+	"vendorId": "0x1EA7",
+	"productId": "0x1F42",
+	"matrix": {
+		"rows": 5,
+		"cols": 13
+	},
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "F3 Mission Control in macOS", "shortName": "Mission Control"},
+    {"name": "Launch Pad", "title": "F4 Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Task View", "title": "F3 Task View in windows", "shortName": "Task View"},
+    {"name": "File Explorer", "title": "F4 File Explorer in windows", "shortName": "File Explorer"},
+    {"name": "Win Mode", "title": "Working in Windows", "shortName": "Win Mode"},
+    {"name": "Mac Mode", "title": "Working in macOS", "shortName": "Mac Mode"},
+    {"name": "Lamp Test", "title": "Led Lamp Test", "shortName": "Lamp Test"},
+    {"name": "Deep Sleep", "title": "Keyboard into Deep Sleep", "shortName": "Deep Sleep"},
+    {"name": "Out Usb", "title": "Keyboard data output USB", "shortName": "Out Usb"},
+    {"name": "Bluetooth 1", "title": "Bluetooth working connection 1", "shortName": "BT 1"},
+    {"name": "Bluetooth 2", "title": "Bluetooth working connection 2", "shortName": "BT 2"},
+	{"name": "Bluetooth 3", "title": "Bluetooth working connection 3", "shortName": "BT 3"}
+  ],
+	"layouts": {
+		"keymap": [
+			[
+				{
+					"x": -1
+				},
+				"0,12",
+				"0,0",
+				"1,12",
+				{
+					"x": 8
+				},
+				"4,6",
+				"4,7"
+			],
+			[
+				"1,0",
+				"1,1",
+				"1,2",
+				"1,3",
+				"1,4",
+				"1,5",
+				"1,6",
+				"1,7",
+				"1,8",
+				"1,9",
+				"1,10",
+				"1,11"
+			],
+			[
+				{
+					"w": 1.25
+				},
+				"2,0",
+				"2,1",
+				"2,2",
+				"2,3",
+				"2,4",
+				"2,5",
+				"2,6",
+				"2,7",
+				"2,8",
+				"2,9",
+				{
+					"w": 1.75
+				},
+				"2,11"
+			],
+			[
+				{
+					"w": 1.75
+				},
+				"3,0",
+				"3,1",
+				"3,2",
+				"3,3",
+				"3,4",
+				"3,5",
+				"3,6",
+				"3,7",
+				"3,8",
+				{
+					"w": 1.25
+				},
+				"3,10",
+				"3,11"
+			],
+			[
+				{
+					"w": 1.25
+				},
+				"4,0",
+				{
+					"w": 1
+				},
+				"4,1",
+				{
+					"w": 1.25
+				},
+				"4,2",
+				{
+					"w": 2.25
+				},
+				"4,4",
+				{
+					"w": 2.75
+				},
+				"4,5",
+				{
+					"w": 1.25
+				},
+				"4,9",
+				"4,10",
+				{
+					"w": 1.25
+				},
+				"4,11"
+			]
+		]
+	}
+}

--- a/v3/ubest/tps40/tps40b.json
+++ b/v3/ubest/tps40/tps40b.json
@@ -1,0 +1,100 @@
+{
+	"name": "tps40b",
+	"vendorId": "0x1EA7",
+	"productId": "0x1F46",
+	"matrix": {
+		"rows": 5,
+		"cols": 13
+	},
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "F3 Mission Control in macOS", "shortName": "Mission Control"},
+    {"name": "Launch Pad", "title": "F4 Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Task View", "title": "F3 Task View in windows", "shortName": "Task View"},
+    {"name": "File Explorer", "title": "F4 File Explorer in windows", "shortName": "File Explorer"},
+    {"name": "Win Mode", "title": "Working in Windows", "shortName": "Win Mode"},
+    {"name": "Mac Mode", "title": "Working in macOS", "shortName": "Mac Mode"},
+    {"name": "Lamp Test", "title": "Led Lamp Test", "shortName": "Lamp Test"},
+    {"name": "Deep Sleep", "title": "Keyboard into Deep Sleep", "shortName": "Deep Sleep"},
+    {"name": "Out Usb", "title": "Keyboard data output USB", "shortName": "Out Usb"},
+    {"name": "Bluetooth 1", "title": "Bluetooth working connection 1", "shortName": "BT 1"},
+    {"name": "Bluetooth 2", "title": "Bluetooth working connection 2", "shortName": "BT 2"},
+	{"name": "Bluetooth 3", "title": "Bluetooth working connection 3", "shortName": "BT 3"}
+  ],
+	"layouts": {
+		"keymap": [
+			[
+				{
+					"x": -1
+				},
+				"0,12",
+				"0,0",
+				"1,12",
+				{
+					"x": 8
+				},
+				"4,6",
+				"4,7"
+			],
+			[
+				"1,0",
+				"1,1",
+				"1,2",
+				"1,3",
+				"1,4",
+				"1,5",
+				"1,6",
+				"1,7",
+				"1,8",
+				"1,9",
+				"1,10",
+				"1,11"
+			],
+			[
+				"2,0",
+				"2,1",
+				"2,2",
+				"2,3",
+				"2,4",
+				"2,5",
+				"2,6",
+				"2,7",
+				"2,8",
+				"2,9",
+				"2,10",
+				"2,11"
+			],
+			[
+				"3,0",
+				"3,1",
+				"3,2",
+				"3,3",
+				"3,4",
+				"3,5",
+				"3,6",
+				"3,7",
+				"3,8",
+				"3,9",
+				"3,10",
+				"3,11"
+			],
+			[
+				"4,0",
+				"4,1",
+				"4,2",
+				"4,3",
+				{
+					"w": 2
+				},
+				"4,4",
+				{
+					"w": 2
+				},
+				"4,5",
+				"4,8",
+				"4,9",
+				"4,10",
+				"4,11"
+			]
+		]
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
tps40a:ZB31A1UB0-42KEY
tps40b:ZB31B1UB0-46KEY

<!--- Describe your changes in detail here. -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
