### PR TITLE
Add Chocopad Rev. 1 and Rev. 2

### DIFF
--- a/v3/keebio/chocopad/chocopad-rev1.json
+++ b/v3/keebio/chocopad/chocopad-rev1.json
@@ -1,0 +1,16 @@
+{
+  "name": "Chocopad Rev. 1", 
+  "vendorId": "0xCB10", 
+  "productId": "0x1144", 
+  "matrix": {"rows": 4, "cols": 4}, 
+  "keycodes": ["qmk_lighting"], 
+  "menus": ["qmk_backlight_rgblight"], 
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2", "0,3"], 
+      ["1,0", "1,1", "1,2", "1,3"], 
+      ["2,0", "2,1", "2,2", "2,3"], 
+      ["3,0", "3,1", "3,2", "3,3"]
+    ]
+  }
+}

--- a/v3/keebio/chocopad/chocopad-rev2.json
+++ b/v3/keebio/chocopad/chocopad-rev2.json
@@ -1,0 +1,16 @@
+{
+  "name": "Chocopad Rev. 2", 
+  "vendorId": "0xCB10", 
+  "productId": "0x2144", 
+  "matrix": {"rows": 4, "cols": 4}, 
+  "keycodes": ["qmk_lighting"], 
+  "menus": ["qmk_rgb_matrix"], 
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2", "0,3"], 
+      ["1,0", "1,1", "1,2", "1,3"], 
+      ["2,0", "2,1", "2,2", "2,3"], 
+      ["3,0", "3,1", "3,2", "3,3"]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Add Chocopad Rev. 1 and Rev. 2

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/21563

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
