### PR TITLE
add RGB to jels60 in VIA

### DIFF
--- a/src/jels/jels60/jels60_via.json
+++ b/src/jels/jels60/jels60_via.json
@@ -2,9 +2,7 @@
   "name": "Jels60",
   "vendorId": "0x006A",
   "productId": "0x0060",
-  "lighting": {
-    "extends": "none"
-  },
+  "lighting": "qmk_rgblight",
   "matrix": {"rows": 5, "cols": 14},
   "layouts": {
     "labels": [

--- a/v3/jels/jels60/jels60_via.json
+++ b/v3/jels/jels60/jels60_via.json
@@ -2,6 +2,12 @@
   "name": "Jels60",
   "vendorId": "0x006A",
   "productId": "0x0060",
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus":[
+    "qmk_rgblight"
+  ],
   "matrix": {"rows": 5, "cols": 14},
   "layouts": {
     "labels": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

add support for underglow added on a later version of the PCB

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/16605

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
