### PR TITLE
Add support for CXT Studio

### DIFF
--- a/v3/cxt/studio.json
+++ b/v3/cxt/studio.json
@@ -1,0 +1,48 @@
+{
+  "name": "CXT Studio",
+  "vendorId": "0xC401",
+  "productId": "0x5754",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
+  "matrix": {
+    "rows": 4,
+    "cols": 4
+  },
+  "layouts": {
+    "keymap": [
+      [
+        "0,0",
+        "0,1",
+        "0,2",
+        "0,3",
+        "3,2\n\n\n\n\n\n\n\n\ne2",
+        "3,3\n\n\n\n\n\n\n\n\ne3"
+      ],
+      [
+        "1,0",
+        "1,1",
+        "1,2",
+        "1,3",
+        {
+          "w": 2,
+          "h": 2
+        },
+        "3,1\n\n\n\n\n\n\n\n\ne1"
+      ],
+      [
+        "2,0",
+        "2,1",
+        "2,2",
+        "2,3"
+      ],
+      [
+        {
+          "x": 4,
+          "w": 2,
+          "h": 2
+        },
+        "3,0\n\n\n\n\n\n\n\n\ne0"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/21675

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
