### PR TITLE
Add VIA support for cf81

### DIFF
--- a/v3/chosfox/cf81.json
+++ b/v3/chosfox/cf81.json
@@ -1,0 +1,233 @@
+{
+    "name": "CHOSFOX CF81",
+    "vendorId": "0xFFFE",
+    "productId": "0x0012",
+    "keycodes": ["qmk_lighting"],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 200],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  ["All Off", 0],
+                  ["SOLID_COLOR", 1],
+                  ["BREATHING", 2],
+                  ["CYCLE_ALL", 3],
+                  ["CYCLE_LEFT_RIGHT", 4],
+                  ["CYCLE_UP_DOWN", 5],
+                  ["RAINBOW_MOVING_CHEVRON", 6],
+                  ["CYCLE_OUT_IN", 7],
+                  ["CYCLE_OUT_IN_DUAL", 8],
+                  ["CYCLE_PINWHEEL", 9],
+                  ["CYCKE_SPIRAL", 10],
+                  ["DUAL_BEACON", 11],
+                  ["RAINBOW_BEACON", 12],
+                  ["RAINDROPS", 13],
+                  ["TYPING_HEATMAP", 14],
+                  ["SOLID_REACTIVE_SIMPLE", 15],
+                  ["SOLID_REACTIVE", 16],
+                  ["SOLID_REACTIVE_CROSS", 17],
+                  ["MATRIX_MULTISPLASH", 18]
+
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "matrix": { "rows": 6, "cols": 16 },
+    "layouts": {
+        "keymap":[
+            [
+              {
+                "c": "#777777"
+              },
+              "0,0",
+              {
+                "c": "#AAAAAA"
+              },
+              "0,1",
+              "0,2",
+              "0,3",
+              "0,4",
+              "0,5",
+              "0,6",
+              "0,7",
+              "0,8",
+              "0,9",
+              "0,10",
+              "0,11",
+              "0,12",
+              {
+                "x": 0.5
+              },
+              "0,13",
+              {
+                "x": 0.5
+              },
+              "0,15\n\n\n\n\n\n\n\n\ne0"
+            ],
+            [
+              "1,0\n`",
+              {
+                "c": "#cccccc"
+              },
+              "1,1",
+              "1,2",
+              "1,3",
+              "1,4",
+              "1,5",
+              "1,6",
+              "1,7",
+              "1,8",
+              "1,9",
+              "1,10",
+              "1,11",
+              "1,12",
+              {
+                "c": "#AAAAAA",
+                "w": 2
+              },
+              "1,13",
+              "1,15"
+            ],
+            [
+              {
+                "w": 1.5
+              },
+              "2,0",
+              {
+                "c": "#cccccc"
+              },
+              "2,1",
+              "2,2",
+              "2,3",
+              "2,4",
+              "2,5",
+              "2,6",
+              "2,7",
+              "2,8",
+              "2,9",
+              "2,10",
+              "2,11",
+              "2,12",
+              {
+                "c": "#AAAAAA",
+                "w": 1.5
+              },
+              "2,13",
+              "2,15"
+            ],
+            [
+              {
+                "w": 1.75
+              },
+              "3,0",
+              {
+                "c": "#cccccc"
+              },
+              "3,1",
+              "3,2",
+              "3,3",
+              "3,4",
+              "3,5",
+              "3,6",
+              "3,7",
+              "3,8",
+              "3,9",
+              "3,10",
+              "3,11",
+              {
+                "c": "#777777",
+                "w": 2.25
+              },
+              "3,13",
+              {
+                "c": "#AAAAAA"
+              },
+              "3,15"
+            ],
+            [
+              {
+                "w": 2.25
+              },
+              "4,0",
+              {
+                "c": "#cccccc"
+              },
+              "4,1",
+              "4,2",
+              "4,3",
+              "4,4",
+              "4,5",
+              "4,6",
+              "4,7",
+              "4,8",
+              "4,9",
+              "4,10",
+              {
+                "c": "#AAAAAA",
+                "w": 1.75
+              },
+              "4,13",
+              {
+                "c": "#777777"
+              },
+              "4,14"
+            ],
+            [
+              {
+                "w": 1.25
+              },
+              "5,0",
+              {
+                "w": 1.25
+              },
+              "5,1",
+              {
+                "w": 1.25
+              },
+              "5,2",
+              {
+                "w": 6.25
+              },
+              "5,5",
+              "5,9",
+              "5,10",
+              "5,11",
+              {
+                "c": "#777777"
+              },
+              "5,13",
+              "5,14",
+              "5,15"
+            ]
+          ]
+        }
+      }

--- a/v3/chosfox/cf81.json
+++ b/v3/chosfox/cf81.json
@@ -31,7 +31,7 @@
                   ["CYCLE_OUT_IN", 7],
                   ["CYCLE_OUT_IN_DUAL", 8],
                   ["CYCLE_PINWHEEL", 9],
-                  ["CYCKE_SPIRAL", 10],
+                  ["CYCLE_SPIRAL", 10],
                   ["DUAL_BEACON", 11],
                   ["RAINBOW_BEACON", 12],
                   ["RAINDROPS", 13],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add VIA support for chosfox cf81
<!--- Describe your changes in detail here. -->

## QMK Pull Request 
https://github.com/qmk/qmk_firmware/pull/21437
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
