### PR TITLE
Add Binepad PIXIE

### DIFF
--- a/v3/binepad/pixie/pixie.json
+++ b/v3/binepad/pixie/pixie.json
@@ -1,0 +1,12 @@
+{
+    "name": "Binepad PIXIE",
+    "vendorId": "0x4249",
+    "productId": "0x5078",
+    "matrix": {"rows": 2, "cols": 2},
+    "layouts": {
+        "keymap": [
+            ["0,0\n\n\n\n\n\n\n\n\ne0",{"x":0.25},"0,1\n\n\n\n\n\n\n\n\ne1"],
+            [{"y":0.25},"1,0",{"x":0.25},"1,1"]
+        ]
+    }
+}


### PR DESCRIPTION
## Description

Adding Binepad PIXIE keyboard, an RP2040 based 2x2 macro keypad featuring 2 rotary encoders and 2 macro buttons.

## QMK Pull Request 

* https://github.com/qmk/qmk_firmware/pull/21524

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
