### PR TITLE
Add VIA support for Treasure TYPE-9 Series III

### DIFF
--- a/v3/treasure/type9s3.json
+++ b/v3/treasure/type9s3.json
@@ -3,7 +3,62 @@
     "vendorId": "0x5452",
     "productId": "0x5493",
     "keycodes": ["qmk_lighting"],
-    "menus": ["qmk_rgb_matrix" ],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  ["00. None", 0],
+                  ["01. SOLID_COLOR", 1],
+                  ["02. GRADIENT_UP_DOWN", 2],
+                  ["03. GRADIENT_LEFT_RIGHT", 3],
+                  ["04. BREATHING", 4],
+                  ["05. CYCLE_ALL", 5],
+                  ["06. CYCLE_LEFT_RIGHT", 6],
+                  ["07. CYCLE_UP_DOWN", 7],
+                  ["08. JELLYBEAN_RAINDROPS", 8],
+                  ["09. PIXEL_FRACTAL", 9],
+                  ["10. PIXEL_RAIN", 10],
+                  ["11. TYPING_HEATMAP", 11],
+                  ["12. DIGITAL_RAIN", 12],
+                  ["13. SOLID_REACTIVE_SIMPLE", 13],
+                  ["14. SOLID_REACTIVE_MULTIWIDE", 14],
+                  ["15. SOLID_REACTIVE_NEXUS", 15],
+                  ["16. SPLASH", 16],
+                  ["17. SOLID_SPLASH", 17]
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
     "matrix": {
       "rows": 3,
       "cols": 3

--- a/v3/treasure/type9s3.json
+++ b/v3/treasure/type9s3.json
@@ -1,0 +1,31 @@
+{
+    "name": "Treasure TYPE-9 Series III",
+    "vendorId": "0x5452",
+    "productId": "0x5493",
+    "keycodes": ["qmk_lighting"],
+    "menus": ["qmk_rgb_matrix" ],
+    "matrix": {
+      "rows": 3,
+      "cols": 3
+    },
+    "layouts": {
+      "labels": [],
+      "keymap": [
+        [
+          "0,0",
+          "0,1",
+          "0,2"
+        ],
+        [
+          "1,0",
+          "1,1",
+          "1,2"
+        ],
+        [
+          "2,0",
+          "2,1",
+          "2,2"
+        ]
+      ]
+    }
+  }

--- a/v3/treasure/type9s3.json
+++ b/v3/treasure/type9s3.json
@@ -9,7 +9,6 @@
       "cols": 3
     },
     "layouts": {
-      "labels": [],
       "keymap": [
         [
           "0,0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding VIA support for the Treasure TYPE-9 Series III Keyboard

## QMK Pull Request 

It is merged 
https://github.com/qmk/qmk_firmware/pull/21748

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
