### PR TITLE
Create 1upslider8.json

### DIFF
--- a/v3/1upkeyboards/1upslider8/1upslider8.json
+++ b/v3/1upkeyboards/1upslider8/1upslider8.json
@@ -1,5 +1,5 @@
 {
-    "name": "1upslider8",
+    "name": "1up Slider8",
     "vendorId": "0x6F75",
     "productId": "0x5611",
     "matrix": { "rows": 1, "cols": 9},

--- a/v3/1upkeyboards/1upslider8/1upslider8.json
+++ b/v3/1upkeyboards/1upslider8/1upslider8.json
@@ -1,0 +1,132 @@
+{
+    "name": "1upslider8",
+    "vendorId": "0x6F75",
+    "productId": "0x5611",
+    "matrix": { "rows": 1, "cols": 9},
+    "keycodes": ["qmk_lighting"],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  "All Off",
+                  "Solid Color",
+                  "Alphas/Mods",
+                  "Gradient Up/Down",
+                  "Gradient Left/Right",
+                  "Breathing",
+                  "Band Sat.",
+                  "Band Val.",
+                  "Pinwheel Sat.",
+                  "Pinwheel Val.",
+                  "Spiral Sat.",
+                  "Spiral Val.",
+                  "Cycle All",
+                  "Cycle Left/Right",
+                  "Cycle Up/Down",
+                  "Rainbow Moving Chevron",
+                  "Cycle Out/In",
+                  "Cycle Out/In Dual",
+                  "Cycle Pinwheel",
+                  "Cycle Spiral",
+                  "Dual Beacon",
+                  "Rainbow Beacon",
+                  "Rainbow Pinwheels",
+                  "Raindrops",
+                  "Jellybean Raindrops",
+                  "Hue Breathing",
+                  "Hue Pendulum",
+                  "Hue Wave",
+                  "Pixel Rain",
+                  "Pixel Flow",
+                  "Pixel Fractal",
+                  "Typing Heatmap",
+                  "Digital Rain",
+                  "Solid Reactive Simple",
+                  "Solid Reactive",
+                  "Solid Reactive Wide",
+                  "Solid Reactive Multiwide",
+                  "Solid Reactive Cross",
+                  "Solid Reactive Multicross",
+                  "Solid Reactive Nexus",
+                  "Solid Reactive Multinexus",
+                  "Splash",
+                  "Multisplash",
+                  "Solid Splash",
+                  "Solid Multisplash"
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 1 && {id_qmk_rgb_matrix_effect} != 2 && {id_qmk_rgb_matrix_effect} != 3 && {id_qmk_rgb_matrix_effect} != 4",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} == 2",
+                "label": "Mod Color",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} == 2",
+                "label": "Alpha Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} == 3 || {id_qmk_rgb_matrix_effect} == 4",
+                "label": "Gradient Range",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 2 &&{id_qmk_rgb_matrix_effect} != 23 && {id_qmk_rgb_matrix_effect} != 27 && {id_qmk_rgb_matrix_effect} != 28",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "layouts": {
+      "keymap": [
+        [
+          {
+            "x": 3
+          },
+          "0,0\n\n\n\n\n\n\n\n\ne0"
+        ],
+        [
+          "0,1",
+          "0,2",
+          "0,3",
+          "0,4"
+        ],
+        [
+          "0,5",
+          "0,6",
+          "0,7",
+          "0,8"
+        ]
+      ]
+    }
+  }


### PR DESCRIPTION
First commit of the configuration for the 1upkeyboards slider8 macropad

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Configuration for the 1upkeyboards slider8 macropad, a 2x4 ortholinear macro pad with an oled, midi slider, and rotary encoder with per-key RGB. The keyboard is offered as a solder kit, and uses a pi pico as a controller

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/21546

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
