### PR TITLE
Fix  Command BACKLIGHT_CONFIG_GET_VALUE has bad response #251

### DIFF
--- a/v3/crkbd/crkbd.json
+++ b/v3/crkbd/crkbd.json
@@ -3,7 +3,7 @@
   "vendorId": "0x4653",
   "productId": "0x0001",
   "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgblight"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {"rows": 8, "cols": 6},
   "layouts": {
     "keymap": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This is a fix for issue https://github.com/the-via/releases/issues/251.
Error Command BACKLIGHT_CONFIG_GET_VALUE has bad response for crbkd.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There was a issue with the latest QMK Firmware and the V3 enchangesments. The crbk don't use  "qmk_rgblight" in the default Firmware. Instead it uses "qmk_rgb_matrix".

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/tree/master/keyboards/crkbd
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
