### PR TITLE
Add is0gr to VIA

### DIFF
--- a/v3/cannonkeys/is0gr/is0gr.json
+++ b/v3/cannonkeys/is0gr/is0gr.json
@@ -1,0 +1,25 @@
+{
+    "name": "is0GR",
+    "vendorId": "0xCA04",
+    "productId": "0x0028",
+    "matrix": {
+        "rows": 1,
+        "cols": 1
+    },
+    "layouts": {
+        "keymap": [
+            [
+                {
+                    "x": 0.25,
+                    "c": "#aaaaaa",
+                    "w": 1.25,
+                    "h": 2,
+                    "w2": 1.5,
+                    "h2": 1,
+                    "x2": -0.25
+                },
+                "0,0"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding i0gr to VIA
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

https://github.com/qmk/qmk_firmware/pull/22024

It's in master QMK

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
