### PR TITLE
Add support for ploopyco/madromys

### DIFF
--- a/v3/ploopyco/trackball/trackball_adept.json
+++ b/v3/ploopyco/trackball/trackball_adept.json
@@ -1,0 +1,49 @@
+{
+  "name": "Ploopy Adept Trackball",
+  "vendorId": "0x5043",
+  "productId": "0x5C47",
+  "customKeycodes": [
+    {"name": "DPI Config", "title": "DPI Config", "shortName": "DPI"},
+    {"name": "Drag Scroll", "title": "Drag Scroll", "shortName": "DragScl"}
+  ],
+  "matrix": {"rows": 1, "cols": 6},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "h": 2
+        },
+        "0,1",
+        {
+          "x": 0.25,
+          "h": 1.25
+        },
+        "0,2",
+        {
+          "x": 0.25,
+          "h": 1.25
+        },
+        "0,3",
+        {
+          "x": 0.25,
+          "h": 2
+        },
+        "0,4"
+      ],
+      [
+        {
+          "y": 1.25,
+          "w": 1.75,
+          "h": 2
+        },
+        "0,0",
+        {
+          "x": 1.25,
+          "w": 1.75,
+          "h": 2
+        },
+        "0,5"
+      ]
+    ]
+  }
+}

--- a/v3/ploopyco/trackball/trackball_madromys.json
+++ b/v3/ploopyco/trackball/trackball_madromys.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ploopy Adept Trackball",
+  "name": "Ploopy Adept Trackball (Madromys)",
   "vendorId": "0x5043",
   "productId": "0x5C47",
   "customKeycodes": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add support for ploopyco/madromys

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

https://github.com/qmk/qmk_firmware/pull/21989

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
