### PR TITLE
Add Coban Pad 9A

### DIFF
--- a/v3/coban/pad9a/pad9a.json
+++ b/v3/coban/pad9a/pad9a.json
@@ -1,0 +1,25 @@
+{
+    "name": "Coban Pad 9A",
+    "vendorId": "0xCB3A",
+    "productId": "0xCC9A",
+    "keycodes": ["qmk_lighting"],
+    "menus": ["qmk_rgb_matrix"],
+    "matrix": { "rows": 1, "cols": 8 },
+    "layouts": {
+        "keymap": [
+            [
+                "0,0\n\n\n\n\n\n\n\n\ne0",
+                {"y": 0, "x": 1},
+                "0,1\n\n\n\n\n\n\n\n\ne1",
+                {"y": 1.15, "x": -3},
+                "0,2",
+                "0,3",
+                "0,4",
+                {"y": 1, "x": -3},
+                "0,5",
+                "0,6",
+                "0,7"
+            ]
+        ]
+    }
+}

--- a/v3/coban/pad9a/pad9a.json
+++ b/v3/coban/pad9a/pad9a.json
@@ -3,7 +3,57 @@
     "vendorId": "0xCB3A",
     "productId": "0xCC9A",
     "keycodes": ["qmk_lighting"],
-    "menus": ["qmk_rgb_matrix"],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  "All Off",
+                  "Solid Color",
+                  "Breathing",
+                  "Cycle All",
+                  "Rainbow Beacon",
+                  "Raindrops",
+                  "Pixel Rain",
+                  "Typing Heatmap",
+                  "Digital Rain",
+                  "Solid Reactive Simple",
+                  "Solid Reactive Wide",
+                  "Solid Reactive Nexus",
+                  "Spash"
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
     "matrix": { "rows": 1, "cols": 8 },
     "layouts": {
         "keymap": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add Coban Pad 9A small macro keyboard

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/22456

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
