### PR TITLE
Add Laser Ninja Pumpkinpad

### DIFF
--- a/src/laser_ninja/pumpkinpad/pumpkinpad.json
+++ b/src/laser_ninja/pumpkinpad/pumpkinpad.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pumpkinpad",
+  "vendorId": "0x6C6E",
+  "productId": "0x7070",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
+  "matrix": {
+    "rows": 3,
+    "cols": 4
+  },
+  "layouts": {
+    "keymap": [
+      [{"x":0.5}, "0,0","0,1","0,2"],
+      ["1,0", "1,1", "1,2", "1,3"],
+      [{"x":0.5}, "2,0", "2,1", "2,2"]
+    ]
+  }
+}

--- a/src/laser_ninja/pumpkinpad/pumpkinpad.json
+++ b/src/laser_ninja/pumpkinpad/pumpkinpad.json
@@ -2,8 +2,7 @@
   "name": "Pumpkinpad",
   "vendorId": "0x6C6E",
   "productId": "0x7070",
-  "keycodes": ["qmk_lighting"],
-  "menus": ["qmk_rgb_matrix"],
+  "lighting": "qmk_rgblight",
   "matrix": {
     "rows": 3,
     "cols": 4

--- a/v3/laser_ninja/pumpkinpad/pumpkinpad.json
+++ b/v3/laser_ninja/pumpkinpad/pumpkinpad.json
@@ -1,0 +1,17 @@
+{
+  "name": "Pumpkinpad",
+  "vendorId": "0x6C6E",
+  "productId": "0x7070",
+  "lighting": "qmk_rgblight",
+  "matrix": {
+    "rows": 3,
+    "cols": 4
+  },
+  "layouts": {
+    "keymap": [
+      [{"x":0.5}, "0,0","0,1","0,2"],
+      ["1,0", "1,1", "1,2", "1,3"],
+      [{"x":0.5}, "2,0", "2,1", "2,2"]
+    ]
+  }
+}

--- a/v3/laser_ninja/pumpkinpad/pumpkinpad.json
+++ b/v3/laser_ninja/pumpkinpad/pumpkinpad.json
@@ -2,7 +2,8 @@
   "name": "Pumpkinpad",
   "vendorId": "0x6C6E",
   "productId": "0x7070",
-  "lighting": "qmk_rgblight",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
   "matrix": {
     "rows": 3,
     "cols": 4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As per title.

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->


QMK: https://github.com/qmk/qmk_firmware/tree/master/keyboards/laser_ninja/pumpkin_pad/keymaps/via
<!--- THIS IS MANDATORY. -->

**Note:** [There is a pending pull request to change the naming in QMK](https://github.com/qmk/qmk_firmware/pull/22651). Hence, I have opened this pull request matching the new naming. 

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
