### PR TITLE
Added The Mad Noodle Folder and noodlepad_micro Keypad

### DIFF
--- a/v3/themadnoodle/noodlepad_micro.json
+++ b/v3/themadnoodle/noodlepad_micro.json
@@ -1,0 +1,34 @@
+{
+    "name": "NoodlePad Micro",
+    "vendorId": "0x6A6C",
+    "productId": "0x0004",
+    "keycodes": ["qmk_lighting"],
+    "menus": ["qmk_rgblight"],
+    "matrix": {
+        "rows": 3,
+        "cols": 3
+    },
+    "layouts": {
+        "keymap": [
+            [
+                {"c": "#777777" },
+                "0,2\n\n\n\n\n\n\n\n\ne0",
+                {"x": 1},
+                "0,0\n\n\n\n\n\n\n\n\ne1"
+            ],
+            [
+                {"c": "#cccccc"},
+                "1,2",
+                "1,1",
+                "1,0"
+            ],
+            [
+                "2,2",
+                "2,1",
+                "2,0"
+            ]
+        ]
+    }
+
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I'm a small keypad maker, [The Mad Noodle ](https://www.madnoodleprototypes.com/), and I'm slowly working adding Via support for all of the keypads I've offered past and future. 

This is for the Latest keypad, which I'm hopefully gonna be ready to launch in the coming few weeks! 
So, I was trying to add this keypad to your repository/firmware list as soon as I could so I could link it directly in all of the setup guides that come with the purchased keypads since I plan to ship with the via keymap already installed. 

I've tested everything on the keypad (firmware and design tab in Vias web app and desktop app), so all should be working perfectly :-) 

<!--- Describe your changes in detail here. -->

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/22703

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
