### PR TITLE
Add new BAMFK-1 Rev. 1 definition

### DIFF
--- a/v3/keebio/bamfk1/bamfk1-rev1a.json
+++ b/v3/keebio/bamfk1/bamfk1-rev1a.json
@@ -1,0 +1,19 @@
+{
+  "name": "BAMFK-1",
+  "vendorId": "0xcb10",
+  "productId": "0x1211",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgb_matrix"],
+  "matrix": {"rows": 1, "cols": 3},
+  "layouts": {
+    "keymap": [
+      [ {"x": 1.5, "w": 2, "h": 2}, "0,0" ],
+      [
+        {"y": 1.25, "x": 0.5},
+        "0,1\n\n\n\n\n\n\n\n\ne0",
+        {"x": 2},
+        "0,2\n\n\n\n\n\n\n\n\ne1"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

- Adds support for encoder map and RGB matrix

## QMK Pull Request 

https://github.com/qmk/qmk_firmware/pull/23236

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
