### PR TITLE
Update Zed60 Add lighting keycode

### DIFF
--- a/v3/mechlovin/zed60/zed60.json
+++ b/v3/mechlovin/zed60/zed60.json
@@ -2,6 +2,7 @@
   "name": "Zed60 Rev.1",
   "vendorId": "0x4D4C",
   "productId": "0x0602",
+  "keycodes": [ "qmk_lighting" ],
   "menus": [
     {
       "label": "Lighting",


### PR DESCRIPTION
add support lighting keycode

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add lighting keycode for Zed60. 
Thanks.
<!--- Describe your changes in detail here. -->

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
