### PR TITLE
Add VIA support for Keychron C2 Pro V2

### DIFF
--- a/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_Non-Backlit.json
+++ b/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_Non-Backlit.json
@@ -1,0 +1,272 @@
+{
+  "name": "Keychron C2 Pro V2 ANSI Non-Backlit",
+  "vendorId": "0x3434",
+  "productId": "0x052C",
+  "keycodes": ["qmk_lighting"],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "LOpt"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "ROpt"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "LCmd"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "RCmd"},
+    {"name": "Siri", "title": "Siri in macOS", "shortName": "Siri"},
+    {"name": "Task View", "title": "Task View in windows", "shortName": "Task"},
+    {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot", "title": "Screenshot in macOS", "shortName": "SShot"},
+    {"name": "Cortana", "title": "Cortana in windows", "shortName": "Cortana"},
+    {"name": "Lock WinOS", "title": "Lock screen in windows", "shortName": "LockW"},
+    {"name": "Lock MacOS", "title": "Lock screen in macOS", "shortName": "LockM"}
+  ],
+  "matrix": {"rows": 6, "cols": 21},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,14",
+        "0,15",
+        "0,16"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "1,13",
+        {
+          "x": 0.25
+        },
+        "1,14",
+        "1,15",
+        "1,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "1,17",
+        "1,18",
+        "1,19",
+        "1,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,13",
+        {
+          "x": 0.25
+        },
+        "2,14",
+        "2,15",
+        "2,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "2,17",
+        "2,18",
+        "2,19",
+        {
+          "h": 2
+        },
+        "2,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "3,13",
+        {
+          "x": 3.5,
+          "c": "#cccccc"
+        },
+        "3,17",
+        "3,18",
+        "3,19"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "c": "#aaaaaa",
+          "w": 2.75
+        },
+        "4,13",
+        {
+          "x": 1.25,
+          "c": "#777777"
+        },
+        "4,15",
+        {
+          "x": 1.25,
+          "c": "#cccccc"
+        },
+        "4,17",
+        "4,18",
+        "4,19",
+        {
+          "h": 2
+        },
+        "4,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,0",
+        {
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "5,6",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,10",
+        {
+          "w": 1.25
+        },
+        "5,11",
+        {
+          "w": 1.25
+        },
+        "5,12",
+        {
+          "w": 1.25
+        },
+        "5,13",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "5,14",
+        "5,15",
+        "5,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc",
+          "w": 2
+        },
+        "5,17",
+        "5,18"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_rgb.json
+++ b/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_rgb.json
@@ -1,0 +1,331 @@
+{
+  "name": "Keychron C2 Pro ANSI RGB",
+  "vendorId": "0x3434",
+  "productId": "0x0526",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCLE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "LOpt"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "ROpt"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "LCmd"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "RCmd"},
+    {"name": "Siri", "title": "Siri in macOS", "shortName": "Siri"},
+    {"name": "Task View", "title": "Task View in windows", "shortName": "Task"},
+    {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot", "title": "Screenshot in macOS", "shortName": "SShot"},
+    {"name": "Cortana", "title": "Cortana in windows", "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 6, "cols": 21},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,14",
+        "0,15",
+        "0,16"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "1,13",
+        {
+          "x": 0.25
+        },
+        "1,14",
+        "1,15",
+        "1,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "1,17",
+        "1,18",
+        "1,19",
+        "1,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,13",
+        {
+          "x": 0.25
+        },
+        "2,14",
+        "2,15",
+        "2,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "2,17",
+        "2,18",
+        "2,19",
+        {
+          "h": 2
+        },
+        "2,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "3,13",
+        {
+          "x": 3.5,
+          "c": "#cccccc"
+        },
+        "3,17",
+        "3,18",
+        "3,19"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "c": "#aaaaaa",
+          "w": 2.75
+        },
+        "4,13",
+        {
+          "x": 1.25,
+          "c": "#777777"
+        },
+        "4,15",
+        {
+          "x": 1.25,
+          "c": "#cccccc"
+        },
+        "4,17",
+        "4,18",
+        "4,19",
+        {
+          "h": 2
+        },
+        "4,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,0",
+        {
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "5,6",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,10",
+        {
+          "w": 1.25
+        },
+        "5,11",
+        {
+          "w": 1.25
+        },
+        "5,12",
+        {
+          "w": 1.25
+        },
+        "5,13",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "5,14",
+        "5,15",
+        "5,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc",
+          "w": 2
+        },
+        "5,17",
+        "5,18"
+      ]
+    ]
+  }
+}

--- a/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_white.json
+++ b/v3/keychron/c2_pro_v2/c2_pro_ansi_v2_white.json
@@ -1,0 +1,270 @@
+{
+  "name": "Keychron C2 Pro ANSI White",
+  "vendorId": "0x3434",
+  "productId": "0x0529",
+  "keycodes": ["qmk_lighting"],
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "MCtrl"},
+    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "LPad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "LOpt"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "ROpt"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "LCmd"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "RCmd"},
+    {"name": "Siri", "title": "Siri in macOS", "shortName": "Siri"},
+    {"name": "Task View", "title": "Task View in windows", "shortName": "Task"},
+    {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File"},
+    {"name": "Screen Shot", "title": "Screenshot in macOS", "shortName": "SShot"},
+    {"name": "Cortana", "title": "Cortana in windows", "shortName": "Cortana"}
+  ],
+  "matrix": {"rows": 6, "cols": 21},
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0\nESC",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,14",
+        "0,15",
+        "0,16"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "1,13",
+        {
+          "x": 0.25
+        },
+        "1,14",
+        "1,15",
+        "1,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "1,17",
+        "1,18",
+        "1,19",
+        "1,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,13",
+        {
+          "x": 0.25
+        },
+        "2,14",
+        "2,15",
+        "2,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "2,17",
+        "2,18",
+        "2,19",
+        {
+          "h": 2
+        },
+        "2,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "3,13",
+        {
+          "x": 3.5,
+          "c": "#cccccc"
+        },
+        "3,17",
+        "3,18",
+        "3,19"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "c": "#aaaaaa",
+          "w": 2.75
+        },
+        "4,13",
+        {
+          "x": 1.25,
+          "c": "#777777"
+        },
+        "4,15",
+        {
+          "x": 1.25,
+          "c": "#cccccc"
+        },
+        "4,17",
+        "4,18",
+        "4,19",
+        {
+          "h": 2
+        },
+        "4,20"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,0",
+        {
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "5,6",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,10",
+        {
+          "w": 1.25
+        },
+        "5,11",
+        {
+          "w": 1.25
+        },
+        "5,12",
+        {
+          "w": 1.25
+        },
+        "5,13",
+        {
+          "x": 0.25,
+          "c": "#777777"
+        },
+        "5,14",
+        "5,15",
+        "5,16",
+        {
+          "x": 0.25,
+          "c": "#cccccc",
+          "w": 2
+        },
+        "5,17",
+        "5,18"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
This is to add support to the **V2** of the Keychron C2 Pro. The files were fetched from the link below and formatted to my best knowledge of this repo. 

[link](https://www.keychron.com/blogs/archived/how-to-factory-reset-or-flash-your-qmk-via-enabled-keychron-c2-pro-keyboard)

_I can see that QMK VIA support is merged for C2 Pro, but do not see for C2 Pro V2. I don't know how that works. Just don't want to carry this **json** everywhere._

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
