### PR TITLE
Add new versions of Sat75 to VIA

### DIFF
--- a/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
+++ b/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
@@ -1,0 +1,348 @@
+{
+  "name": "Satisfaction75 HS",
+  "vendorId": "0xca04",
+  "productId": "0x0011",
+  "menus": [
+    {
+      "label": "Custom Features",
+      "content": [
+        {
+          "label": "General",
+          "content": [
+            {
+              "label": "Default OLED Mode",
+              "type": "dropdown",
+              "options": [
+                ["Default", 0],
+                ["Time", 1],
+                ["Off", 2]
+              ],
+              "content": ["default_oled_mode", 0, 2]
+            },
+            {
+              "label": "Current OLED Mode",
+              "type": "dropdown",
+              "options": [
+                ["Default", 0],
+                ["Time", 1],
+                ["Off", 2]
+              ],
+              "content": ["current_oled_mode", 0, 4]
+            }
+          ]
+        },
+        {
+          "label": "Custom Encoder Configuration",
+          "content": [
+            {
+              "label": "Custom 0 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][0]", 0, 3, 0, 0]
+            },
+            {
+              "label": "Custom 0 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][1]", 0, 3, 0, 1]
+            },
+            {
+              "label": "Custom 0 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][2]", 0, 3, 0, 2]
+            },
+            {
+              "label": "Custom 1 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][0]", 0, 3, 1, 0]
+            },
+            {
+              "label": "Custom 1 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][1]", 0, 3, 1, 1]
+            },
+            {
+              "label": "Custom 1 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][2]", 0, 3, 1, 2]
+            },
+            {
+              "label": "Custom 2 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][0]", 0, 3, 2, 0]
+            },
+            {
+              "label": "Custom 2 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][1]", 0, 3, 2, 1]
+            },
+            {
+              "label": "Custom 2 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][2]", 0, 3, 2, 2]
+            }
+          ]
+        },
+        {
+          "label": "Enabled Encoder Modes",
+          "content": [
+            {
+              "label": "Volume",
+              "type": "toggle",
+              "content": ["id_encoder_modes[0]", 0, 1, 0]
+            },
+            {
+              "label": "Media",
+              "type": "toggle",
+              "content": ["id_encoder_modes[1]", 0, 1, 1]
+            },
+            {
+              "label": "Scroll",
+              "type": "toggle",
+              "content": ["id_encoder_modes[2]", 0, 1, 2]
+            },
+            {
+              "label": "Brightness",
+              "type": "toggle",
+              "content": ["id_encoder_modes[3]", 0, 1, 3]
+            },
+            {
+              "label": "Backlight",
+              "type": "toggle",
+              "content": ["id_encoder_modes[4]", 0, 1, 4]
+            },
+            {
+              "label": "Custom 0",
+              "type": "toggle",
+              "content": ["id_encoder_modes[5]", 0, 1, 5]
+            },
+            {
+              "label": "Custom 1",
+              "type": "toggle",
+              "content": ["id_encoder_modes[6]", 0, 1, 6]
+            },
+            {
+              "label": "Custom 2",
+              "type": "toggle",
+              "content": ["id_encoder_modes[7]", 0, 1, 7]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Encoder Press", "title": "Encoder Press", "shortName": "EncPrs"},
+    {"name": "Clock Set", "title": "Clock Set", "shortName": "ClkSet"},
+    {"name": "OLED Mode", "title": "OLED Mode", "shortName": "ScrnMd"}
+  ],
+  "matrix": {"rows": 6, "cols": 15},
+  "layouts": {
+    "labels": [
+      "Split Backspace"
+    ],
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "0,10",
+        "0,11",
+        "0,12",
+        "0,13"
+      ],
+      [
+        {
+          "x": 15.5,
+          "c": "#aaaaaa"
+        },
+        "1,14"
+      ],
+      [
+        {
+          "y": -0.75
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "1,13\n\n\n0,0",
+        {
+          "x": 2
+        },
+        "1,13\n\n\n0,1",
+        "0,14\n\n\n0,1"
+      ],
+      [
+        {
+          "w": 1.5
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "2,13",
+        {
+          "x": 0.5
+        },
+        "2,14"
+      ],
+      [
+        {
+          "w": 1.75
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "3,13",
+        {
+          "x": 0.5
+        },
+        "3,14"
+      ],
+      [
+        {
+          "w": 2.25
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "4,12",
+        {
+          "x": 1.5
+        },
+        "4,14"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 14.25,
+          "c": "#777777"
+        },
+        "4,13"
+      ],
+      [
+        {
+          "y": -0.25,
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,0",
+        {
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "5,6",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "5,10",
+        {
+          "w": 1.5
+        },
+        "5,11"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 13.25,
+          "c": "#777777"
+        },
+        "5,12",
+        "5,13",
+        "5,14"
+      ]
+    ]
+  }
+}

--- a/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
+++ b/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
@@ -1,7 +1,28 @@
 {
   "name": "Satisfaction75 HS",
-  "vendorId": "0xca04",
+  "vendorId": "0xCA04",
   "productId": "0x0011",
+  "matrix": {
+    "rows": 6,
+    "cols": 15
+  },
+  "customKeycodes": [
+    {
+      "name": "Encoder Press",
+      "title": "Encoder Press",
+      "shortName": "EncPrs"
+    },
+    {
+      "name": "Clock Set",
+      "title": "Clock Set",
+      "shortName": "ClkSet"
+    },
+    {
+      "name": "OLED Mode",
+      "title": "OLED Mode",
+      "shortName": "ScrnMd"
+    }
+  ],
   "menus": [
     {
       "label": "Custom Features",
@@ -13,21 +34,47 @@
               "label": "Default OLED Mode",
               "type": "dropdown",
               "options": [
-                ["Default", 0],
-                ["Time", 1],
-                ["Off", 2]
+                [
+                  "Default",
+                  0
+                ],
+                [
+                  "Time",
+                  1
+                ],
+                [
+                  "Off",
+                  2
+                ]
               ],
-              "content": ["default_oled_mode", 0, 2]
+              "content": [
+                "default_oled_mode",
+                0,
+                2
+              ]
             },
             {
               "label": "Current OLED Mode",
               "type": "dropdown",
               "options": [
-                ["Default", 0],
-                ["Time", 1],
-                ["Off", 2]
+                [
+                  "Default",
+                  0
+                ],
+                [
+                  "Time",
+                  1
+                ],
+                [
+                  "Off",
+                  2
+                ]
               ],
-              "content": ["current_oled_mode", 0, 4]
+              "content": [
+                "current_oled_mode",
+                0,
+                4
+              ]
             }
           ]
         },
@@ -37,47 +84,101 @@
             {
               "label": "Custom 0 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][0]", 0, 3, 0, 0]
+              "content": [
+                "id_encoder_custom[0][0]",
+                0,
+                3,
+                0,
+                0
+              ]
             },
             {
               "label": "Custom 0 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][1]", 0, 3, 0, 1]
+              "content": [
+                "id_encoder_custom[0][1]",
+                0,
+                3,
+                0,
+                1
+              ]
             },
             {
               "label": "Custom 0 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][2]", 0, 3, 0, 2]
+              "content": [
+                "id_encoder_custom[0][2]",
+                0,
+                3,
+                0,
+                2
+              ]
             },
             {
               "label": "Custom 1 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][0]", 0, 3, 1, 0]
+              "content": [
+                "id_encoder_custom[1][0]",
+                0,
+                3,
+                1,
+                0
+              ]
             },
             {
               "label": "Custom 1 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][1]", 0, 3, 1, 1]
+              "content": [
+                "id_encoder_custom[1][1]",
+                0,
+                3,
+                1,
+                1
+              ]
             },
             {
               "label": "Custom 1 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][2]", 0, 3, 1, 2]
+              "content": [
+                "id_encoder_custom[1][2]",
+                0,
+                3,
+                1,
+                2
+              ]
             },
             {
               "label": "Custom 2 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][0]", 0, 3, 2, 0]
+              "content": [
+                "id_encoder_custom[2][0]",
+                0,
+                3,
+                2,
+                0
+              ]
             },
             {
               "label": "Custom 2 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][1]", 0, 3, 2, 1]
+              "content": [
+                "id_encoder_custom[2][1]",
+                0,
+                3,
+                2,
+                1
+              ]
             },
             {
               "label": "Custom 2 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][2]", 0, 3, 2, 2]
+              "content": [
+                "id_encoder_custom[2][2]",
+                0,
+                3,
+                2,
+                2
+              ]
             }
           ]
         },
@@ -87,54 +188,88 @@
             {
               "label": "Volume",
               "type": "toggle",
-              "content": ["id_encoder_modes[0]", 0, 1, 0]
+              "content": [
+                "id_encoder_modes[0]",
+                0,
+                1,
+                0
+              ]
             },
             {
               "label": "Media",
               "type": "toggle",
-              "content": ["id_encoder_modes[1]", 0, 1, 1]
+              "content": [
+                "id_encoder_modes[1]",
+                0,
+                1,
+                1
+              ]
             },
             {
               "label": "Scroll",
               "type": "toggle",
-              "content": ["id_encoder_modes[2]", 0, 1, 2]
+              "content": [
+                "id_encoder_modes[2]",
+                0,
+                1,
+                2
+              ]
             },
             {
               "label": "Brightness",
               "type": "toggle",
-              "content": ["id_encoder_modes[3]", 0, 1, 3]
+              "content": [
+                "id_encoder_modes[3]",
+                0,
+                1,
+                3
+              ]
             },
             {
               "label": "Backlight",
               "type": "toggle",
-              "content": ["id_encoder_modes[4]", 0, 1, 4]
+              "content": [
+                "id_encoder_modes[4]",
+                0,
+                1,
+                4
+              ]
             },
             {
               "label": "Custom 0",
               "type": "toggle",
-              "content": ["id_encoder_modes[5]", 0, 1, 5]
+              "content": [
+                "id_encoder_modes[5]",
+                0,
+                1,
+                5
+              ]
             },
             {
               "label": "Custom 1",
               "type": "toggle",
-              "content": ["id_encoder_modes[6]", 0, 1, 6]
+              "content": [
+                "id_encoder_modes[6]",
+                0,
+                1,
+                6
+              ]
             },
             {
               "label": "Custom 2",
               "type": "toggle",
-              "content": ["id_encoder_modes[7]", 0, 1, 7]
+              "content": [
+                "id_encoder_modes[7]",
+                0,
+                1,
+                7
+              ]
             }
           ]
         }
       ]
     }
   ],
-  "customKeycodes": [
-    {"name": "Encoder Press", "title": "Encoder Press", "shortName": "EncPrs"},
-    {"name": "Clock Set", "title": "Clock Set", "shortName": "ClkSet"},
-    {"name": "OLED Mode", "title": "OLED Mode", "shortName": "ScrnMd"}
-  ],
-  "matrix": {"rows": 6, "cols": 15},
   "layouts": {
     "labels": [
       "Split Backspace"
@@ -346,3 +481,4 @@
     ]
   }
 }
+

--- a/v3/cannonkeys/satisfaction75_rev2/satisfaction75_rev2.json
+++ b/v3/cannonkeys/satisfaction75_rev2/satisfaction75_rev2.json
@@ -1,0 +1,407 @@
+{
+  "name": "Satisfaction75 Rev 2",
+  "vendorId": "0xca04",
+  "productId": "0x001A",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    "qmk_backlight",
+    {
+      "label": "Custom Features",
+      "content": [
+        {
+          "label": "General",
+          "content": [
+            {
+              "label": "Default OLED Mode",
+              "type": "dropdown",
+              "options": [
+                ["Default", 0],
+                ["Time", 1],
+                ["Off", 2]
+              ],
+              "content": ["default_oled_mode", 0, 2]
+            },
+            {
+              "label": "Current OLED Mode",
+              "type": "dropdown",
+              "options": [
+                ["Default", 0],
+                ["Time", 1],
+                ["Off", 2]
+              ],
+              "content": ["current_oled_mode", 0, 4]
+            }
+          ]
+        },
+        {
+          "label": "Custom Encoder Configuration",
+          "content": [
+            {
+              "label": "Custom 0 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][0]", 0, 3, 0, 0]
+            },
+            {
+              "label": "Custom 0 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][1]", 0, 3, 0, 1]
+            },
+            {
+              "label": "Custom 0 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[0][2]", 0, 3, 0, 2]
+            },
+            {
+              "label": "Custom 1 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][0]", 0, 3, 1, 0]
+            },
+            {
+              "label": "Custom 1 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][1]", 0, 3, 1, 1]
+            },
+            {
+              "label": "Custom 1 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[1][2]", 0, 3, 1, 2]
+            },
+            {
+              "label": "Custom 2 - CW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][0]", 0, 3, 2, 0]
+            },
+            {
+              "label": "Custom 2 - CCW",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][1]", 0, 3, 2, 1]
+            },
+            {
+              "label": "Custom 2 - Press",
+              "type": "keycode",
+              "content": ["id_encoder_custom[2][2]", 0, 3, 2, 2]
+            }
+          ]
+        },
+        {
+          "label": "Enabled Encoder Modes",
+          "content": [
+            {
+              "label": "Volume",
+              "type": "toggle",
+              "content": ["id_encoder_modes[0]", 0, 1, 0]
+            },
+            {
+              "label": "Media",
+              "type": "toggle",
+              "content": ["id_encoder_modes[1]", 0, 1, 1]
+            },
+            {
+              "label": "Scroll",
+              "type": "toggle",
+              "content": ["id_encoder_modes[2]", 0, 1, 2]
+            },
+            {
+              "label": "Brightness",
+              "type": "toggle",
+              "content": ["id_encoder_modes[3]", 0, 1, 3]
+            },
+            {
+              "label": "Backlight",
+              "type": "toggle",
+              "content": ["id_encoder_modes[4]", 0, 1, 4]
+            },
+            {
+              "label": "Custom 0",
+              "type": "toggle",
+              "content": ["id_encoder_modes[5]", 0, 1, 5]
+            },
+            {
+              "label": "Custom 1",
+              "type": "toggle",
+              "content": ["id_encoder_modes[6]", 0, 1, 6]
+            },
+            {
+              "label": "Custom 2",
+              "type": "toggle",
+              "content": ["id_encoder_modes[7]", 0, 1, 7]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "customKeycodes": [
+    {"name": "Encoder Press", "title": "Encoder Press", "shortName": "EncPrs"},
+    {"name": "Clock Set", "title": "Clock Set", "shortName": "ClkSet"},
+    {"name": "OLED Mode", "title": "OLED Mode", "shortName": "ScrnMd"}
+  ],
+  "matrix": {"rows": 6, "cols": 15},
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      "ISO Enter",
+      "Split L-Shift",
+      ["Spacebar", "6.25U", "7U"],
+      ["Right Mods","3x1U","2x1.5U"]
+    ],
+    "keymap": [
+      [
+        {
+          "x": 2.5,
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "0,10",
+        "0,11",
+        "0,12",
+        "0,13"
+      ],
+      [
+        {
+          "y": -0.25,
+          "x": 18,
+          "c": "#aaaaaa"
+        },
+        "1,14\n\n\n\n\n\n\n\n\ne"
+      ],
+      [
+        {
+          "y": -0.5,
+          "x": 2.5,
+          "c": "#cccccc"
+        },
+        "1,0",
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "1,13\n\n\n0,0",
+        {
+          "x": 2.25,
+          "c": "#cccccc"
+        },
+        "1,13\n\n\n0,1",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n0,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "w": 1.5
+        },
+        "2,13\n\n\n1,0",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "2,14",
+        {
+          "x": 1.5,
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "3,13\n\n\n1,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.75
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "3,13\n\n\n1,0",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "3,14",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "2,13\n\n\n1,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,0\n\n\n2,1",
+        {
+          "c": "#cccccc"
+        },
+        "4,1\n\n\n2,1",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "4,0\n\n\n2,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "4,12",
+        {
+          "x": 1.5
+        },
+        "4,14"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 16.75
+        },
+        "4,13"
+      ],
+      [
+        {
+          "y": -0.25,
+          "x": 2.5,
+          "w": 1.25
+        },
+        "5,0\n\n\n3,0",
+        {
+          "w": 1.25
+        },
+        "5,1\n\n\n3,0",
+        {
+          "w": 1.25
+        },
+        "5,2\n\n\n3,0",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "5,6\n\n\n3,0",
+        {
+          "c": "#aaaaaa"
+        },
+        "5,9\n\n\n4,0",
+        "5,10\n\n\n4,0",
+        "5,11\n\n\n4,0"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 15.75
+        },
+        "5,12",
+        "5,13",
+        "5,14"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "5,0\n\n\n3,1",
+        {
+          "w": 1.5
+        },
+        "5,1\n\n\n3,1",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "5,6\n\n\n3,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "5,10\n\n\n4,1",
+        {
+          "w": 1.5
+        },
+        "5,11\n\n\n4,1"
+      ]
+    ]
+  }
+}

--- a/v3/cannonkeys/satisfaction75_rev2/satisfaction75_rev2.json
+++ b/v3/cannonkeys/satisfaction75_rev2/satisfaction75_rev2.json
@@ -1,8 +1,31 @@
 {
   "name": "Satisfaction75 Rev 2",
-  "vendorId": "0xca04",
+  "vendorId": "0xCA04",
   "productId": "0x001A",
-  "keycodes": ["qmk_lighting"],
+  "matrix": {
+    "rows": 6,
+    "cols": 15
+  },
+  "customKeycodes": [
+    {
+      "name": "Encoder Press",
+      "title": "Encoder Press",
+      "shortName": "EncPrs"
+    },
+    {
+      "name": "Clock Set",
+      "title": "Clock Set",
+      "shortName": "ClkSet"
+    },
+    {
+      "name": "OLED Mode",
+      "title": "OLED Mode",
+      "shortName": "ScrnMd"
+    }
+  ],
+  "keycodes": [
+    "qmk_lighting"
+  ],
   "menus": [
     "qmk_backlight",
     {
@@ -15,21 +38,47 @@
               "label": "Default OLED Mode",
               "type": "dropdown",
               "options": [
-                ["Default", 0],
-                ["Time", 1],
-                ["Off", 2]
+                [
+                  "Default",
+                  0
+                ],
+                [
+                  "Time",
+                  1
+                ],
+                [
+                  "Off",
+                  2
+                ]
               ],
-              "content": ["default_oled_mode", 0, 2]
+              "content": [
+                "default_oled_mode",
+                0,
+                2
+              ]
             },
             {
               "label": "Current OLED Mode",
               "type": "dropdown",
               "options": [
-                ["Default", 0],
-                ["Time", 1],
-                ["Off", 2]
+                [
+                  "Default",
+                  0
+                ],
+                [
+                  "Time",
+                  1
+                ],
+                [
+                  "Off",
+                  2
+                ]
               ],
-              "content": ["current_oled_mode", 0, 4]
+              "content": [
+                "current_oled_mode",
+                0,
+                4
+              ]
             }
           ]
         },
@@ -39,47 +88,101 @@
             {
               "label": "Custom 0 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][0]", 0, 3, 0, 0]
+              "content": [
+                "id_encoder_custom[0][0]",
+                0,
+                3,
+                0,
+                0
+              ]
             },
             {
               "label": "Custom 0 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][1]", 0, 3, 0, 1]
+              "content": [
+                "id_encoder_custom[0][1]",
+                0,
+                3,
+                0,
+                1
+              ]
             },
             {
               "label": "Custom 0 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[0][2]", 0, 3, 0, 2]
+              "content": [
+                "id_encoder_custom[0][2]",
+                0,
+                3,
+                0,
+                2
+              ]
             },
             {
               "label": "Custom 1 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][0]", 0, 3, 1, 0]
+              "content": [
+                "id_encoder_custom[1][0]",
+                0,
+                3,
+                1,
+                0
+              ]
             },
             {
               "label": "Custom 1 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][1]", 0, 3, 1, 1]
+              "content": [
+                "id_encoder_custom[1][1]",
+                0,
+                3,
+                1,
+                1
+              ]
             },
             {
               "label": "Custom 1 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[1][2]", 0, 3, 1, 2]
+              "content": [
+                "id_encoder_custom[1][2]",
+                0,
+                3,
+                1,
+                2
+              ]
             },
             {
               "label": "Custom 2 - CW",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][0]", 0, 3, 2, 0]
+              "content": [
+                "id_encoder_custom[2][0]",
+                0,
+                3,
+                2,
+                0
+              ]
             },
             {
               "label": "Custom 2 - CCW",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][1]", 0, 3, 2, 1]
+              "content": [
+                "id_encoder_custom[2][1]",
+                0,
+                3,
+                2,
+                1
+              ]
             },
             {
               "label": "Custom 2 - Press",
               "type": "keycode",
-              "content": ["id_encoder_custom[2][2]", 0, 3, 2, 2]
+              "content": [
+                "id_encoder_custom[2][2]",
+                0,
+                3,
+                2,
+                2
+              ]
             }
           ]
         },
@@ -89,61 +192,103 @@
             {
               "label": "Volume",
               "type": "toggle",
-              "content": ["id_encoder_modes[0]", 0, 1, 0]
+              "content": [
+                "id_encoder_modes[0]",
+                0,
+                1,
+                0
+              ]
             },
             {
               "label": "Media",
               "type": "toggle",
-              "content": ["id_encoder_modes[1]", 0, 1, 1]
+              "content": [
+                "id_encoder_modes[1]",
+                0,
+                1,
+                1
+              ]
             },
             {
               "label": "Scroll",
               "type": "toggle",
-              "content": ["id_encoder_modes[2]", 0, 1, 2]
+              "content": [
+                "id_encoder_modes[2]",
+                0,
+                1,
+                2
+              ]
             },
             {
               "label": "Brightness",
               "type": "toggle",
-              "content": ["id_encoder_modes[3]", 0, 1, 3]
+              "content": [
+                "id_encoder_modes[3]",
+                0,
+                1,
+                3
+              ]
             },
             {
               "label": "Backlight",
               "type": "toggle",
-              "content": ["id_encoder_modes[4]", 0, 1, 4]
+              "content": [
+                "id_encoder_modes[4]",
+                0,
+                1,
+                4
+              ]
             },
             {
               "label": "Custom 0",
               "type": "toggle",
-              "content": ["id_encoder_modes[5]", 0, 1, 5]
+              "content": [
+                "id_encoder_modes[5]",
+                0,
+                1,
+                5
+              ]
             },
             {
               "label": "Custom 1",
               "type": "toggle",
-              "content": ["id_encoder_modes[6]", 0, 1, 6]
+              "content": [
+                "id_encoder_modes[6]",
+                0,
+                1,
+                6
+              ]
             },
             {
               "label": "Custom 2",
               "type": "toggle",
-              "content": ["id_encoder_modes[7]", 0, 1, 7]
+              "content": [
+                "id_encoder_modes[7]",
+                0,
+                1,
+                7
+              ]
             }
           ]
         }
       ]
     }
   ],
-  "customKeycodes": [
-    {"name": "Encoder Press", "title": "Encoder Press", "shortName": "EncPrs"},
-    {"name": "Clock Set", "title": "Clock Set", "shortName": "ClkSet"},
-    {"name": "OLED Mode", "title": "OLED Mode", "shortName": "ScrnMd"}
-  ],
-  "matrix": {"rows": 6, "cols": 15},
   "layouts": {
     "labels": [
       "Split Backspace",
       "ISO Enter",
       "Split L-Shift",
-      ["Spacebar", "6.25U", "7U"],
-      ["Right Mods","3x1U","2x1.5U"]
+      [
+        "Spacebar",
+        "6.25U",
+        "7U"
+      ],
+      [
+        "Right Mods",
+        "3x1U",
+        "2x1.5U"
+      ]
     ],
     "keymap": [
       [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding the new versions of the Satisfaction75 PCBs to VIA.

The matricies are all difference - hence two JSONs being added on top of the existing Sat75 PCB in VIA.

## QMK Pull Request 

These two PCBs made it into QMK master with the last develop -> master train
https://github.com/qmk/qmk_firmware/pull/22082


<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
