### PR TITLE
GH60 additions

### DIFF
--- a/v3/gh60/revc/revc.json
+++ b/v3/gh60/revc/revc.json
@@ -97,7 +97,11 @@
         "3,13\n\n\n3,0",
         {"x": 0.25, "w": 1.75},
         "3,13\n\n\n3,1",
-        "3,12\n\n\n3,1"
+        "3,12\n\n\n3,1",
+        {"c": "#cccccc", "x": 0.25}, 
+        "3,12\n\n\n3,2",
+        {"c": "#aaaaaa", "w": 1.75},
+        "3,13\n\n\n3,2"
       ],
       [
         {"x": 2.5, "w": 1.25},
@@ -161,14 +165,41 @@
         "4,12\n\n\n4,3",
         {"c": "#cccccc", "w": 1.5, "d": true},
         "\n\n\n4,3"
+      ],
+      [
+        {"c": "#aaaaaa", "x": 2.5, "w": 1.5},
+        "4,0\n\n\n4,4",
+        "4,1\n\n\n4,4",
+        {"w": 1.5},
+        "4,2\n\n\n4,4",
+        {"c": "#cccccc", "w": 6},
+        "4,5\n\n\n4,4",
+        {"c": "#aaaaaa", "w": 1.5},
+        "4,10\n\n\n4,4",
+        "4,11\n\n\n4,4",
+        "4,12\n\n\n4,4",
+        {"w": 1.5},
+        "4,13\n\n\n4,4"
+      ],
+      [
+        {"x": 2.5, "w": 1.5, "d": true},
+        "\n\n\n4,5",
+        "4,1\n\n\n4,5",
+        {"w": 1.5},
+        "4,2\n\n\n4,5",
+        {"c": "#cccccc", "w": 6},
+        "4,5\n\n\n4,5",
+        {"c": "#aaaaaa", "w": 1.5},
+        "4,10\n\n\n4,5",
+        "4,11\n\n\n4,5"
       ]
     ],
     "labels": [
       "Split Backspace",
       "ISO Enter",
       "Split Left Shift",
-      "Split Right Shift",
-      ["Bottom Row", "ANSI", "7U", "WKL", "HHKB"]
+      ["Right Shift", "2.75u", "Tsangan", "ABNT2"],
+      ["Bottom Row", "6.25u", "Tsangan", "WKL", "7u HHKB", "infinity", "HHKB"]
     ]
   }
 }

--- a/v3/gh60/satan/satan.json
+++ b/v3/gh60/satan/satan.json
@@ -99,7 +99,11 @@
         "3,13\n\n\n3,0",
         {"x": 0.25, "w": 1.75},
         "3,13\n\n\n3,1",
-        "3,12\n\n\n3,1"
+        "3,12\n\n\n3,1",
+        {"c": "#cccccc", "x": 0.25},
+        "3,12\n\n\n3,2",
+        {"c": "#aaaaaa", "w": 1.75},
+        "3,13\n\n\n3,2"
       ],
       [
         {"x": 2.5, "w": 1.25},
@@ -163,14 +167,41 @@
         "4,12\n\n\n4,3",
         {"c": "#cccccc", "w": 1.5, "d": true},
         "\n\n\n4,3"
+      ],
+      [
+        {"c": "#aaaaaa", "x": 2.5, "w": 1.5},
+        "4,0\n\n\n4,4",
+        "4,1\n\n\n4,4",
+        {"w": 1.5},
+        "4,2\n\n\n4,4",
+        {"c": "#cccccc", "w": 6},
+        "4,5\n\n\n4,4",
+        {"c": "#aaaaaa", "w": 1.5},
+        "4,10\n\n\n4,4",
+        "4,11\n\n\n4,4",
+        "4,12\n\n\n4,4",
+        {"w": 1.5},
+        "4,13\n\n\n4,4"
+      ],
+      [
+        {"x": 2.5, "w": 1.5, "d": true},
+        "\n\n\n4,5",
+        "4,1\n\n\n4,5",
+        {"w": 1.5},
+        "4,2\n\n\n4,5",
+        {"c": "#cccccc", "w": 6},
+        "4,5\n\n\n4,5",
+        {"c": "#aaaaaa", "w": 1.5},
+        "4,10\n\n\n4,5",
+        "4,11\n\n\n4,5"
       ]
     ],
     "labels": [
       "Split Backspace",
       "ISO Enter",
       "Split Left Shift",
-      "Split Right Shift",
-      ["Bottom Row", "ANSI", "7U", "WKL", "HHKB"]
+      ["Right Shift", "2.75u", "Tsangan", "ABNT2"],
+      ["Bottom Row", "6.25u", "Tsangan", "WKL", "7u HHKB", "infinity", "HHKB"]
     ]
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For both `gh60` boards in `v3` directory, add:
- ABNT2 split Right Shift (1u-1.75u)
    - amend Right Shift in `labels` to accommodate
-  Infinity Hacker and True/6u HHKB bottom row layouts
   - amend bottom row `labels` to accommodate 

## QMK Pull Request 

This PR **does not** add a new keyboard
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
