### PR TITLE
Rename dnworks SBL to dnworks 60percent

### DIFF
--- a/v3/dnworks/60percent/60percent.json
+++ b/v3/dnworks/60percent/60percent.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnworks SBL",
+  "name": "dnworks 60%",
   "vendorId": "0x4C23",
   "productId": "0x2934",
   "matrix": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I renamed the JSON file and folder from "sbl" to "60percent" due to electronically identical PCBs. For QMK, this renaming was done in the "develop" branch, which has been approved. However, I don't anticipate it will be merged soon (https://github.com/qmk/qmk_firmware/pull/23683).

Would it be more appropriate to revert the changes to the file and folder names, and instead only change the "name" field in the JSON file first? That could serve as a temporary solution until the QMK pull request is merged.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/23683

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
