### PR TITLE
Add Linx3 Fave65S PCB

### DIFF
--- a/v3/era/linx3/fave65s/fave65s.json
+++ b/v3/era/linx3/fave65s/fave65s.json
@@ -1,0 +1,417 @@
+{
+  "name": "FAve65S",
+  "vendorId": "0x4552",
+  "productId": "0x0011",
+  "matrix": {
+    "rows": 5,
+    "cols": 16
+  },
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                [
+                  "All Off",
+                  0
+                ],
+                [
+                  "Solid Color",
+                  1
+                ],
+                [
+                  "Gradient Up/Down",
+                  3
+                ],
+                [
+                  "Gradient Left/Right",
+                  4
+                ],
+                [
+                  "Breathing",
+                  5
+                ],
+                [
+                  "Band Sat.",
+                  6
+                ],
+                [
+                  "Band Val.",
+                  7
+                ],
+                [
+                  "Pinwheel Sat.",
+                  8
+                ],
+                [
+                  "Pinwheel Val.",
+                  9
+                ],
+                [
+                  "Spiral Sat.",
+                  10
+                ],
+                [
+                  "Spiral Val.",
+                  11
+                ],
+                [
+                  "Cycle All",
+                  12
+                ],
+                [
+                  "Cycle Left/Right",
+                  13
+                ],
+                [
+                  "Cycle Up/Down",
+                  14
+                ],
+                [
+                  "Rainbow Moving Chevron",
+                  15
+                ],
+                [
+                  "Cycle Out/In",
+                  16
+                ],
+                [
+                  "Cycle Out/In Dual",
+                  17
+                ],
+                [
+                  "Cycle Pinwheel",
+                  18
+                ],
+                [
+                  "Cycle Spiral",
+                  19
+                ],
+                [
+                  "Dual Beacon",
+                  20
+                ],
+                [
+                  "Rainbow Beacon",
+                  21
+                ],
+                [
+                  "Rainbow Pinwheels",
+                  22
+                ],
+                [
+                  "Flower Blooming",
+                  23
+                ],
+                [
+                  "Raindrops",
+                  24
+                ],
+                [
+                  "Jellybean Raindrops",
+                  25
+                ],
+                [
+                  "Hue Breathing",
+                  26
+                ],
+                [
+                  "Hue Pendulum",
+                  27
+                ],
+                [
+                  "Hue Wave",
+                  28
+                ],
+                [
+                  "Pixel Rain",
+                  29
+                ],
+                [
+                  "Pixel Flow",
+                  30
+                ],
+                [
+                  "Starlight",
+                  32
+                ],
+                [
+                  "Starlight Dual Sat.",
+                  33
+                ],
+                [
+                  "Starlight Dual Hue.",
+                  34
+                ],
+                [
+                  "Riverflow",
+                  35
+                ]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 25 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 30",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      [
+        "Enter",
+        "ANSI",
+        "ISO"
+      ],
+      "Split Left Shift",
+      [
+        "Bottom Row",
+        "6.25U",
+        "7U"
+      ]
+    ],
+    "keymap": [
+    [
+      {
+        "x": 2.5,
+        "c": "#777777"
+      },
+        "0,0",
+      {
+        "c": "#cccccc"
+      },
+      "0,1",
+      "0,2",
+      "0,3",
+      "0,4",
+      "0,5",
+      "0,6",
+      "0,7",
+      "0,8",
+      "0,9",
+      "0,10",
+      "0,11",
+      "0,12",
+      {
+        "c": "#aaaaaa",
+        "w": 2
+      },
+      "0,14\n\n\n0,0",
+      {
+        "c": "#cccccc"
+      },
+      "0,15",
+      {
+        "x": 0.5
+      },
+      "0,13\n\n\n0,1",
+      "0,14\n\n\n0,1"
+      ],
+      [
+      {
+        "x": 2.5,
+        "c": "#aaaaaa",
+        "w": 1.5
+      },
+      "1,0",
+      {
+        "c": "#cccccc"
+      },
+      "1,1",
+      "1,2",
+      "1,3",
+      "1,4",
+      "1,5",
+      "1,6",
+      "1,7",
+      "1,8",
+      "1,9",
+      "1,10",
+      "1,11",
+      "1,12",
+      {
+        "w": 1.5
+      },
+      "1,14\n\n\n1,0",
+      "1,15",
+      {
+        "x": 1.25,
+        "c": "#777777",
+        "w": 1.25,
+        "h": 2,
+        "w2": 1.5,
+        "h2": 1,
+        "x2": -0.25
+      },
+      "2,13\n\n\n1,1"
+      ],
+      [
+    {
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.75
+      },
+      "2,0",
+      {
+        "c": "#cccccc"
+      },
+      "2,1",
+      "2,2",
+      "2,3",
+      "2,4",
+      "2,5",
+      "2,6",
+      "2,7",
+      "2,8",
+      "2,9",
+      "2,10",
+      "2,11",
+      {
+        "c": "#777777",
+        "w": 2.25
+      },
+      "2,13\n\n\n1,0",
+      {
+        "c": "#cccccc"
+      },
+      "2,15",
+      {
+        "x": 0.25
+      },
+      "2,12\n\n\n1,1"
+      ],
+      [
+      {
+        "c": "#aaaaaa",
+        "w": 1.25
+      },
+      "3,0\n\n\n2,1",
+      {
+        "c": "#cccccc"
+      },
+      "3,1\n\n\n2,1",
+      {
+        "x": 0.25,
+        "c": "#aaaaaa",
+        "w": 2.25
+      },
+      "3,0\n\n\n2,0",
+      {
+        "c": "#cccccc"
+      },
+      "3,2",
+      "3,3",
+      "3,4",
+      "3,5",
+      "3,6",
+      "3,7",
+      "3,8",
+      "3,9",
+      "3,10",
+      "3,11",
+      {
+        "c": "#aaaaaa",
+        "w": 1.75
+      },
+      "3,12",
+      {
+        "c": "#777777"
+      },
+      "3,14",
+      {
+        "c": "#cccccc"
+      },
+      "3,15"
+      ],
+      [
+      {
+        "x": 2.5,
+        "c": "#aaaaaa",
+        "w": 1.25
+      },
+      "4,0\n\n\n3,0",
+      {
+        "w": 1.25
+      },
+      "4,1\n\n\n3,0",
+      {
+        "w": 1.25
+      },
+      "4,2\n\n\n3,0",
+      {
+        "c": "#cccccc",
+        "w": 6.25
+      },
+      "4,5\n\n\n3,0",
+      {
+        "c": "#aaaaaa",
+        "w": 1.25
+      },
+      "4,10\n\n\n3,0",
+      {
+        "w": 1.25
+      },
+      "4,11\n\n\n3,0",
+      {
+        "x": 0.5,
+        "c": "#777777"
+      },
+      "4,13",
+      "4,14",
+      "4,15"
+      ],
+      [
+      {
+        "y": 0.5,
+        "x": 2.5,
+        "c": "#aaaaaa",
+        "w": 1.5
+      },
+      "4,0\n\n\n3,1",
+      "4,1\n\n\n3,1",
+      {
+        "w": 1.5
+      },
+      "4,2\n\n\n3,1",
+      {
+        "c": "#cccccc",
+        "w": 7
+      },
+      "4,5\n\n\n3,1",
+      {
+        "c": "#aaaaaa",
+        "w": 1.5
+      },
+      "4,11\n\n\n3,1"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Add Linx3 Fave65S PCB

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I would like to add the Fave65S PCB to VIA.
Thanks.
<!--- Describe your changes in detail here. -->

## QMK Pull Request
https://github.com/qmk/qmk_firmware/pull/24034
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
