### PR TITLE
Add extra compatiblity to Sat75 Hotswap PCB

### DIFF
--- a/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
+++ b/v3/cannonkeys/satisfaction75_hs/satisfaction75_hs.json
@@ -1,482 +1,196 @@
 {
-  "name": "Satisfaction75 HS",
-  "vendorId": "0xCA04",
-  "productId": "0x0011",
-  "matrix": {
-    "rows": 6,
-    "cols": 15
-  },
+  "name": "Satisfaction75 HS", 
+  "vendorId": "0xCA04", 
+  "productId": "0x0011", 
+  "matrix": {"rows": 6, "cols": 15}, 
   "customKeycodes": [
-    {
-      "name": "Encoder Press",
-      "title": "Encoder Press",
-      "shortName": "EncPrs"
-    },
-    {
-      "name": "Clock Set",
-      "title": "Clock Set",
-      "shortName": "ClkSet"
-    },
-    {
-      "name": "OLED Mode",
-      "title": "OLED Mode",
-      "shortName": "ScrnMd"
-    }
-  ],
+    {"name": "Encoder Press", "title": "Encoder Press", "shortName": "EncPrs"}, 
+    {"name": "Clock Set", "title": "Clock Set", "shortName": "ClkSet"}, 
+    {"name": "OLED Mode", "title": "OLED Mode", "shortName": "ScrnMd"}
+  ], 
   "menus": [
     {
-      "label": "Custom Features",
+      "label": "Custom Features", 
       "content": [
         {
-          "label": "General",
+          "label": "General", 
           "content": [
             {
-              "label": "Default OLED Mode",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Default",
-                  0
-                ],
-                [
-                  "Time",
-                  1
-                ],
-                [
-                  "Off",
-                  2
-                ]
-              ],
-              "content": [
-                "default_oled_mode",
-                0,
-                2
-              ]
-            },
+              "label": "Default OLED Mode", 
+              "type": "dropdown", 
+              "options": [ ["Default", 0], ["Time", 1], ["Off", 2] ], 
+              "content": ["default_oled_mode", 0, 2]
+            }, 
             {
-              "label": "Current OLED Mode",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Default",
-                  0
-                ],
-                [
-                  "Time",
-                  1
-                ],
-                [
-                  "Off",
-                  2
-                ]
-              ],
-              "content": [
-                "current_oled_mode",
-                0,
-                4
-              ]
+              "label": "Current OLED Mode", 
+              "type": "dropdown", 
+              "options": [ ["Default", 0], ["Time", 1], ["Off", 2] ], 
+              "content": ["current_oled_mode", 0, 4]
             }
           ]
-        },
+        }, 
         {
-          "label": "Custom Encoder Configuration",
+          "label": "Custom Encoder Configuration", 
           "content": [
-            {
-              "label": "Custom 0 - CW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[0][0]",
-                0,
-                3,
-                0,
-                0
-              ]
-            },
-            {
-              "label": "Custom 0 - CCW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[0][1]",
-                0,
-                3,
-                0,
-                1
-              ]
-            },
-            {
-              "label": "Custom 0 - Press",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[0][2]",
-                0,
-                3,
-                0,
-                2
-              ]
-            },
-            {
-              "label": "Custom 1 - CW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[1][0]",
-                0,
-                3,
-                1,
-                0
-              ]
-            },
-            {
-              "label": "Custom 1 - CCW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[1][1]",
-                0,
-                3,
-                1,
-                1
-              ]
-            },
-            {
-              "label": "Custom 1 - Press",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[1][2]",
-                0,
-                3,
-                1,
-                2
-              ]
-            },
-            {
-              "label": "Custom 2 - CW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[2][0]",
-                0,
-                3,
-                2,
-                0
-              ]
-            },
-            {
-              "label": "Custom 2 - CCW",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[2][1]",
-                0,
-                3,
-                2,
-                1
-              ]
-            },
-            {
-              "label": "Custom 2 - Press",
-              "type": "keycode",
-              "content": [
-                "id_encoder_custom[2][2]",
-                0,
-                3,
-                2,
-                2
-              ]
-            }
+            { "label": "Custom 0 - CW", "type": "keycode", "content": ["id_encoder_custom[0][0]", 0, 3, 0, 0] }, 
+            { "label": "Custom 0 - CCW", "type": "keycode", "content": ["id_encoder_custom[0][1]", 0, 3, 0, 1] }, 
+            { "label": "Custom 0 - Press", "type": "keycode", "content": ["id_encoder_custom[0][2]", 0, 3, 0, 2] }, 
+            { "label": "Custom 1 - CW", "type": "keycode", "content": ["id_encoder_custom[1][0]", 0, 3, 1, 0] }, 
+            { "label": "Custom 1 - CCW", "type": "keycode", "content": ["id_encoder_custom[1][1]", 0, 3, 1, 1] }, 
+            { "label": "Custom 1 - Press", "type": "keycode", "content": ["id_encoder_custom[1][2]", 0, 3, 1, 2] }, 
+            { "label": "Custom 2 - CW", "type": "keycode", "content": ["id_encoder_custom[2][0]", 0, 3, 2, 0] }, 
+            { "label": "Custom 2 - CCW", "type": "keycode", "content": ["id_encoder_custom[2][1]", 0, 3, 2, 1] }, 
+            { "label": "Custom 2 - Press", "type": "keycode", "content": ["id_encoder_custom[2][2]", 0, 3, 2, 2] }
           ]
-        },
+        }, 
         {
-          "label": "Enabled Encoder Modes",
+          "label": "Enabled Encoder Modes", 
           "content": [
-            {
-              "label": "Volume",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[0]",
-                0,
-                1,
-                0
-              ]
-            },
-            {
-              "label": "Media",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[1]",
-                0,
-                1,
-                1
-              ]
-            },
-            {
-              "label": "Scroll",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[2]",
-                0,
-                1,
-                2
-              ]
-            },
-            {
-              "label": "Brightness",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[3]",
-                0,
-                1,
-                3
-              ]
-            },
-            {
-              "label": "Backlight",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[4]",
-                0,
-                1,
-                4
-              ]
-            },
-            {
-              "label": "Custom 0",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[5]",
-                0,
-                1,
-                5
-              ]
-            },
-            {
-              "label": "Custom 1",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[6]",
-                0,
-                1,
-                6
-              ]
-            },
-            {
-              "label": "Custom 2",
-              "type": "toggle",
-              "content": [
-                "id_encoder_modes[7]",
-                0,
-                1,
-                7
-              ]
-            }
+            { "label": "Volume", "type": "toggle", "content": ["id_encoder_modes[0]", 0, 1, 0] }, 
+            { "label": "Media", "type": "toggle", "content": ["id_encoder_modes[1]", 0, 1, 1] }, 
+            { "label": "Scroll", "type": "toggle", "content": ["id_encoder_modes[2]", 0, 1, 2] }, 
+            { "label": "Brightness", "type": "toggle", "content": ["id_encoder_modes[3]", 0, 1, 3] }, 
+            { "label": "Backlight", "type": "toggle", "content": ["id_encoder_modes[4]", 0, 1, 4] }, 
+            { "label": "Custom 0", "type": "toggle", "content": ["id_encoder_modes[5]", 0, 1, 5] }, 
+            { "label": "Custom 1", "type": "toggle", "content": ["id_encoder_modes[6]", 0, 1, 6] }, 
+            { "label": "Custom 2", "type": "toggle", "content": ["id_encoder_modes[7]", 0, 1, 7] }
           ]
         }
       ]
     }
-  ],
+  ], 
   "layouts": {
-    "labels": [
-      "Split Backspace"
-    ],
+    "labels": ["Split Backspace", "7U Spacebar", "3x1U Bottom Row"], 
     "keymap": [
       [
-        {
-          "c": "#777777"
-        },
-        "0,0",
-        {
-          "x": 0.5,
-          "c": "#cccccc"
-        },
-        "0,2",
-        "0,3",
-        "0,4",
-        "0,5",
-        {
-          "x": 0.25,
-          "c": "#aaaaaa"
-        },
-        "0,6",
-        "0,7",
-        "0,8",
-        "0,9",
-        {
-          "x": 0.25,
-          "c": "#cccccc"
-        },
-        "0,10",
-        "0,11",
-        "0,12",
+        {"c": "#777777"}, 
+        "0,0", 
+        {"x": 0.5, "c": "#cccccc"}, 
+        "0,2", 
+        "0,3", 
+        "0,4", 
+        "0,5", 
+        {"x": 0.25, "c": "#aaaaaa"}, 
+        "0,6", 
+        "0,7", 
+        "0,8", 
+        "0,9", 
+        {"x": 0.25, "c": "#cccccc"}, 
+        "0,10", 
+        "0,11", 
+        "0,12", 
         "0,13"
-      ],
+      ], 
+      [ {"x": 15.5, "c": "#aaaaaa"}, "1,14" ], 
       [
-        {
-          "x": 15.5,
-          "c": "#aaaaaa"
-        },
-        "1,14"
-      ],
-      [
-        {
-          "y": -0.75
-        },
-        "1,0",
-        {
-          "c": "#cccccc"
-        },
-        "1,1",
-        "1,2",
-        "1,3",
-        "1,4",
-        "1,5",
-        "1,6",
-        "1,7",
-        "1,8",
-        "1,9",
-        "1,10",
-        "1,11",
-        "1,12",
-        {
-          "c": "#aaaaaa",
-          "w": 2
-        },
-        "1,13\n\n\n0,0",
-        {
-          "x": 2
-        },
-        "1,13\n\n\n0,1",
+        {"y": -0.75}, 
+        "1,0", 
+        {"c": "#cccccc"}, 
+        "1,1", 
+        "1,2", 
+        "1,3", 
+        "1,4", 
+        "1,5", 
+        "1,6", 
+        "1,7", 
+        "1,8", 
+        "1,9", 
+        "1,10", 
+        "1,11", 
+        "1,12", 
+        {"c": "#aaaaaa", "w": 2}, 
+        "1,13\n\n\n0,0", 
+        {"x": 2}, 
+        "1,13\n\n\n0,1", 
         "0,14\n\n\n0,1"
-      ],
+      ], 
       [
-        {
-          "w": 1.5
-        },
-        "2,0",
-        {
-          "c": "#cccccc"
-        },
-        "2,1",
-        "2,2",
-        "2,3",
-        "2,4",
-        "2,5",
-        "2,6",
-        "2,7",
-        "2,8",
-        "2,9",
-        "2,10",
-        "2,11",
-        "2,12",
-        {
-          "c": "#aaaaaa",
-          "w": 1.5
-        },
-        "2,13",
-        {
-          "x": 0.5
-        },
+        {"w": 1.5}, 
+        "2,0", 
+        {"c": "#cccccc"}, 
+        "2,1", 
+        "2,2", 
+        "2,3", 
+        "2,4", 
+        "2,5", 
+        "2,6", 
+        "2,7", 
+        "2,8", 
+        "2,9", 
+        "2,10", 
+        "2,11", 
+        "2,12", 
+        {"c": "#aaaaaa", "w": 1.5}, 
+        "2,13", 
+        {"x": 0.5}, 
         "2,14"
-      ],
+      ], 
       [
-        {
-          "w": 1.75
-        },
-        "3,0",
-        {
-          "c": "#cccccc"
-        },
-        "3,1",
-        "3,2",
-        "3,3",
-        "3,4",
-        "3,5",
-        "3,6",
-        "3,7",
-        "3,8",
-        "3,9",
-        "3,10",
-        "3,11",
-        {
-          "c": "#aaaaaa",
-          "w": 2.25
-        },
-        "3,13",
-        {
-          "x": 0.5
-        },
+        {"w": 1.75}, 
+        "3,0", 
+        {"c": "#cccccc"}, 
+        "3,1", 
+        "3,2", 
+        "3,3", 
+        "3,4", 
+        "3,5", 
+        "3,6", 
+        "3,7", 
+        "3,8", 
+        "3,9", 
+        "3,10", 
+        "3,11", 
+        {"c": "#aaaaaa", "w": 2.25}, 
+        "3,13", 
+        {"x": 0.5}, 
         "3,14"
-      ],
+      ], 
       [
-        {
-          "w": 2.25
-        },
-        "4,0",
-        {
-          "c": "#cccccc"
-        },
-        "4,2",
-        "4,3",
-        "4,4",
-        "4,5",
-        "4,6",
-        "4,7",
-        "4,8",
-        "4,9",
-        "4,10",
-        "4,11",
-        {
-          "c": "#aaaaaa",
-          "w": 1.75
-        },
-        "4,12",
-        {
-          "x": 1.5
-        },
+        {"w": 2.25}, 
+        "4,0", 
+        {"c": "#cccccc"}, 
+        "4,2", 
+        "4,3", 
+        "4,4", 
+        "4,5", 
+        "4,6", 
+        "4,7", 
+        "4,8", 
+        "4,9", 
+        "4,10", 
+        "4,11", 
+        {"c": "#aaaaaa", "w": 1.75}, 
+        "4,12", 
+        {"x": 1.5}, 
         "4,14"
-      ],
+      ], 
+      [ {"y": -0.75, "x": 14.25, "c": "#777777"}, "4,13" ], 
       [
-        {
-          "y": -0.75,
-          "x": 14.25,
-          "c": "#777777"
-        },
-        "4,13"
-      ],
+        {"y": -0.25, "c": "#aaaaaa", "w": 1.25}, 
+        "5,0\n\n\n1,0", 
+        {"w": 1.25}, 
+        "5,1\n\n\n1,0", 
+        {"w": 1.25}, 
+        "5,2\n\n\n1,0", 
+        {"c": "#cccccc", "w": 6.25}, 
+        "5,6\n\n\n1,0", 
+        {"c": "#aaaaaa", "w": 1.5}, 
+        "5,10\n\n\n2,0", 
+        {"w": 1.5}, 
+        "5,11\n\n\n2,0"
+      ], 
+      [ {"y": -0.75, "x": 13.25, "c": "#777777"}, "5,12", "5,13", "5,14" ], 
       [
-        {
-          "y": -0.25,
-          "c": "#aaaaaa",
-          "w": 1.25
-        },
-        "5,0",
-        {
-          "w": 1.25
-        },
-        "5,1",
-        {
-          "w": 1.25
-        },
-        "5,2",
-        {
-          "c": "#cccccc",
-          "w": 6.25
-        },
-        "5,6",
-        {
-          "c": "#aaaaaa",
-          "w": 1.5
-        },
-        "5,10",
-        {
-          "w": 1.5
-        },
-        "5,11"
-      ],
-      [
-        {
-          "y": -0.75,
-          "x": 13.25,
-          "c": "#777777"
-        },
-        "5,12",
-        "5,13",
-        "5,14"
+        {"c": "#aaaaaa", "w": 1.5}, 
+        "5,0\n\n\n1,1", 
+        {"w": 1.5}, 
+        "5,1\n\n\n1,1", 
+        {"c": "#cccccc", "w": 7}, 
+        "5,6\n\n\n1,1", 
+        {"c": "#aaaaaa"}, 
+        "5,10\n\n\n2,1", 
+        "5,11\n\n\n2,1", 
+        "5,9\n\n\n2,1"
       ]
     ]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add extra bottom row compatibility on Sat75 Hotswap PCB

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/24156

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
