### PR TITLE
Update the-via/reader dependency to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@the-via/reader": "^1.8.0",
+        "@the-via/reader": "^1.9.0",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
         "@types/rimraf": "^3.0.2",
@@ -62,9 +62,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@the-via/reader": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.8.0.tgz",
-      "integrity": "sha512-XtzO4zbBHlvy0i30N+7O+cTwkeco/+NQW1sjumKoY4+1v41KLJNhxGxqvK/WAKgJ8/whx5J/JLWErC6MXN5WOg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.9.0.tgz",
+      "integrity": "sha512-uvxZpLmzzqh76wMbk9vXFo0fbph7qKNU83AC7gzj09gRGCvOVvN5UIdgm5hwXfAH0DZ9SaL+4e/RRmFpVHwDlQ==",
       "dependencies": {
         "invariant": "^2.2.4",
         "typescript-json-validator": "2.4.2"
@@ -1584,9 +1584,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@the-via/reader": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.8.0.tgz",
-      "integrity": "sha512-XtzO4zbBHlvy0i30N+7O+cTwkeco/+NQW1sjumKoY4+1v41KLJNhxGxqvK/WAKgJ8/whx5J/JLWErC6MXN5WOg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.9.0.tgz",
+      "integrity": "sha512-uvxZpLmzzqh76wMbk9vXFo0fbph7qKNU83AC7gzj09gRGCvOVvN5UIdgm5hwXfAH0DZ9SaL+4e/RRmFpVHwDlQ==",
       "requires": {
         "invariant": "^2.2.4",
         "typescript-json-validator": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "simple-git-hooks": "^2.8.1"
   },
   "dependencies": {
-    "@the-via/reader": "^1.8.0",
+    "@the-via/reader": "^1.9.0",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",
     "@types/rimraf": "^3.0.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
