### PR TITLE
Addition of EC65X

### DIFF
--- a/v3/cipulot/ec_65x/ec_65x.json
+++ b/v3/cipulot/ec_65x/ec_65x.json
@@ -1,0 +1,399 @@
+{
+  "name": "EC 65X",
+  "vendorId": "0x6369",
+  "productId": "0x6BD1",
+  "matrix": {
+    "rows": 5,
+    "cols": 16
+  },
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    "qmk_rgblight",
+    {
+      "label": "EC Tools",
+      "content": [
+        {
+          "label": "Actuation",
+          "content": [
+            {
+              "label": "Mode",
+              "type": "dropdown",
+              "options": ["APC", "Rapid Trigger"],
+              "content": ["id_actuation_mode", 0, 1]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 0",
+              "content": [
+                {
+                  "label": "Actuation Level (0% | 100%)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_0_actuation_threshold", 0, 2]
+                },
+                {
+                  "label": "Release Level (0% | 100%, ALWAYS < Actuation Level)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_0_release_threshold", 0, 3]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 1",
+              "content": [
+                {
+                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_1_initial_deadzone_offset", 0, 5]
+                },
+                {
+                  "label": "Actuation Offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_mode_1_actuation_offset", 0, 6]
+                },
+                {
+                  "label": "Release Offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_mode_1_release_offset", 0, 7]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Calibration",
+          "content": [
+            {
+              "label": "Bottoming Calibration",
+              "type": "toggle",
+              "content": ["id_bottoming_calibration", 0, 8]
+            },
+            {
+              "label": "Noise Floor Calibration (DO NOT PRESS ANY KEY WHILE CLICKING)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_noise_floor_calibration", 0, 9]
+            },
+            {
+              "label": "Show Calibration Data",
+              "type": "button",
+              "options": [0],
+              "content": ["id_show_calibration_data", 0, 10]
+            },
+            {
+              "label": "Clear Bottoming Calibration Data",
+              "type": "button",
+              "options": [0],
+              "content": ["id_clear_bottoming_calibration_data", 0, 11]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      "Split Left Shift",
+      "ISO",
+      ["Bottom Row", "7U", "6.25U", "Split 6.25U", "Bauer"],
+      "Top Blocker"
+    ],
+    "keymap": [
+      [
+        {
+          "x": 15.5
+        },
+        "0,13\n\n\n0,1",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n0,1"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 2.5,
+          "c": "#cccccc"
+        },
+        "0,0",
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13\n\n\n0,0",
+        "0,15\n\n\n4,0",
+        {
+          "x": 1.5,
+          "d": true
+        },
+        "0,15\n\n\n4,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13\n\n\n2,0",
+        {
+          "c": "#aaaaaa"
+        },
+        "1,15",
+        {
+          "x": 1.25,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,14\n\n\n2,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13\n\n\n2,0",
+        {
+          "c": "#aaaaaa"
+        },
+        "2,15",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "2,12\n\n\n2,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "3,0\n\n\n1,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,1\n\n\n1,1",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "3,0\n\n\n1,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,12",
+        "3,14",
+        "3,15"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "4,0\n\n\n3,0",
+        "4,1\n\n\n3,0",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n3,0",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n3,0",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n3,0",
+        {
+          "x": 0.5
+        },
+        "4,12",
+        "4,14",
+        "4,15"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 2.5,
+          "w": 1.25
+        },
+        "4,0\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "4,1\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "4,2\n\n\n3,1",
+        {
+          "c": "#cccccc",
+          "w": 6.25
+        },
+        "4,6\n\n\n3,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,10\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "4,11\n\n\n3,1"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 2.5,
+          "w": 1.25
+        },
+        "4,0\n\n\n3,2",
+        {
+          "w": 1.25
+        },
+        "4,1\n\n\n3,2",
+        {
+          "w": 1.25
+        },
+        "4,2\n\n\n3,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "4,4\n\n\n3,2",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,6\n\n\n3,2",
+        {
+          "c": "#cccccc",
+          "w": 2.75
+        },
+        "4,8\n\n\n3,2",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,10\n\n\n3,2",
+        {
+          "w": 1.25
+        },
+        "4,11\n\n\n3,2"
+      ],
+      [
+        {
+          "y": 0.25,
+          "x": 2.5,
+          "w": 1.5
+        },
+        "4,0\n\n\n3,3",
+        {
+          "w": 0.75,
+          "d": true
+        },
+        "4,1\n\n\n3,3",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n3,3",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n3,3",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n3,3"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request
https://github.com/qmk/qmk_firmware/pull/24648
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request
https://github.com/the-via/qmk_userspace_via/pull/32
<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
