### PR TITLE
Add archerkeyboard/desire65

### DIFF
--- a/v3/archerkeyboard/desire65/desire65.json
+++ b/v3/archerkeyboard/desire65/desire65.json
@@ -6,7 +6,9 @@
     "rows": 5,
     "cols": 16
   },
-  "keycodes": [ "qmk_lighting" ],
+  "keycodes": [
+    "qmk_lighting"
+  ],
   "menus": [
     {
       "label": "Lighting",
@@ -17,13 +19,24 @@
             {
               "label": "Brightness",
               "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_brightness", 2, 1]
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_qmk_rgblight_brightness",
+                2,
+                1
+              ]
             },
             {
               "label": "Effect",
               "type": "dropdown",
-              "content": ["id_qmk_rgblight_effect", 2, 2],
+              "content": [
+                "id_qmk_rgblight_effect",
+                2,
+                2
+              ],
               "options": [
                 "All Off",
                 "Solid Color",
@@ -62,14 +75,25 @@
               "showIf": "{id_qmk_rgblight_effect} != 0",
               "label": "Effect Speed",
               "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_effect_speed", 2, 3]
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_qmk_rgblight_effect_speed",
+                2,
+                3
+              ]
             },
             {
               "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
               "label": "Color",
               "type": "color",
-              "content": ["id_qmk_rgblight_color", 2, 4]
+              "content": [
+                "id_qmk_rgblight_color",
+                2,
+                4
+              ]
             }
           ]
         }
@@ -229,3 +253,4 @@
     ]
   }
 }
+

--- a/v3/archerkeyboard/desire65/desire65.json
+++ b/v3/archerkeyboard/desire65/desire65.json
@@ -1,0 +1,231 @@
+{
+  "name": "desire65",
+  "vendorId": "0x0361",
+  "productId": "0x0002",
+  "matrix": {
+    "rows": 5,
+    "cols": 16
+  },
+  "keycodes": [ "qmk_lighting" ],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Underglow",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgblight_brightness", 2, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgblight_effect", 2, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Breathing 1",
+                "Breathing 2",
+                "Breathing 3",
+                "Breathing 4",
+                "Rainbow Mood 1",
+                "Rainbow Mood 2",
+                "Rainbow Mood 3",
+                "Rainbow Swirl 1",
+                "Rainbow Swirl 2",
+                "Rainbow Swirl 3",
+                "Rainbow Swirl 4",
+                "Rainbow Swirl 5",
+                "Rainbow Swirl 6",
+                "Gradient 1",
+                "Gradient 2",
+                "Gradient 3",
+                "Gradient 4",
+                "Gradient 5",
+                "Gradient 6",
+                "Gradient 7",
+                "Gradient 8",
+                "Gradient 9",
+                "Gradient 10",
+                "Twinkle 1",
+                "Twinkle 2",
+                "Twinkle 3",
+                "Twinkle 4",
+                "Twinkle 5",
+                "Twinkle 6"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgblight_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgblight_effect_speed", 2, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgblight_color", 2, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Split Backspace"
+    ],
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,14\n\n\n0,0",
+        "0,15",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "0,13\n\n\n0,1",
+        "0,14\n\n\n0,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        "1,13",
+        {
+          "w": 1.5
+        },
+        "1,14",
+        {
+          "c": "#aaaaaa"
+        },
+        "1,15"
+      ],
+      [
+        {
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,14",
+        {
+          "c": "#aaaaaa"
+        },
+        "2,15"
+      ],
+      [
+        {
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13",
+        "3,14",
+        "3,15"
+      ],
+      [
+        {
+          "w": 1.5
+        },
+        "4,0",
+        "4,2",
+        {
+          "w": 1.5
+        },
+        "4,3",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,7",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11",
+        {
+          "x": 0.5
+        },
+        "4,13",
+        "4,14",
+        "4,15"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Add VIA support for new keyboard PCB desire65.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/23776
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->
https://github.com/the-via/qmk_userspace_via/commit/0740d86916818c4999d29840ce0eda3eaecd3fa4
<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
