### PR TITLE
Updated 40percentclub vendor IDs for mf68 & nein

### DIFF
--- a/src/40percentclub/mf68/mf68.json
+++ b/src/40percentclub/mf68/mf68.json
@@ -1,6 +1,6 @@
 {
   "name": "MF68",
-  "vendorId": "0x3430",
+  "vendorId": "0x4025",
   "productId": "0x4D68",
   "matrix": {
     "rows": 8,

--- a/src/40percentclub/nein/nein.json
+++ b/src/40percentclub/nein/nein.json
@@ -1,6 +1,6 @@
 {
   "name": "nein",
-  "vendorId": "0x3430",
+  "vendorId": "0x4025",
   "productId": "0x9999",
   "matrix": {
     "rows": 3,

--- a/v3/40percentclub/mf68/mf68.json
+++ b/v3/40percentclub/mf68/mf68.json
@@ -1,6 +1,6 @@
 {
   "name": "MF68",
-  "vendorId": "0x3430",
+  "vendorId": "0x4025",
   "productId": "0x4D68",
   "matrix": {
     "rows": 8,

--- a/v3/40percentclub/nein/nein.json
+++ b/v3/40percentclub/nein/nein.json
@@ -1,6 +1,6 @@
 {
   "name": "nein",
-  "vendorId": "0x3430",
+  "vendorId": "0x4025",
   "productId": "0x9999",
   "matrix": {
     "rows": 3,


### PR DESCRIPTION
## Description

The former USB vendor ID used with 40percentclub keyboards was officially registered to another vendor. A new ID has been generated in QMK. This pull requests brings VIA in sync with QMK.

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
