### PR TITLE
[VIA] Add Support for Monsgeek M5

### DIFF
--- a/src/monsgeek/m5.json
+++ b/src/monsgeek/m5.json
@@ -1,0 +1,345 @@
+{
+    "name": "MonsGeek M5",
+    "vendorId": "0xFFFE",
+    "productId": "0x000A",
+    "keycodes": ["qmk_lighting"],
+    "menus": [
+      {
+        "label": "Lighting",
+        "content": [
+          {
+            "label": "Backlight",
+            "content": [
+              {
+                "label": "Brightness",
+                "type": "range",
+                "options": [0, 200],
+                "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              },
+              {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                  ["All Off", 0],
+                  ["Solid Color", 1],
+                  ["Alphas Mods", 2],
+                  ["Gradient Up/Down", 3],
+                  ["Gradient Left/Right", 4],
+                  ["Breathing", 5],
+                  ["Band Sat.", 6],
+                  ["Band Val.", 7],
+                  ["Pinwheel Sat.", 8],
+                  ["Pinwheel Val.", 9],
+                  ["Spiral Sat.", 10],
+                  ["Spiral Val.", 11],
+                  ["Cycle All", 12],
+                  ["Cycle Left/Right", 13],
+                  ["Cycle Up/Down", 14],
+                  ["Rainbow Moving Chevron", 15],
+                  ["Cycle Out/In", 16],
+                  ["Cycle Out/In Dual", 17],
+                  ["Cycle Pinwheel", 18],
+                  ["Cycle Spiral", 19],
+                  ["Dual Beacon", 20],
+                  ["Rainbow Beacon", 21],
+                  ["Rainbow Pinwheels", 22],
+                  ["Raindrops", 23],
+                  ["Jellybean Raindrops", 24],
+                  ["Hue Breathing", 25],
+                  ["Hue Pendulum", 26],
+                  ["Hue Wave", 27],
+                  ["Pixel Rain", 28],
+                  ["Pixel Flow", 29],
+                  ["Pixel Fractal", 30],
+                  ["Typing Heatmap", 31],
+                  ["Digital Rain", 32],
+                  ["Solid Reactive Simple", 33],
+                  ["Solid Reactive", 34],
+                  ["Solid Reactive Wide", 35],
+                  ["Solid Reactive Multi Wide", 36],
+                  ["Solid Reactive Cross", 37],
+                  ["Solid Reactive Multi Cross", 38],
+                  ["Solid Reactive Nexus", 39],
+                  ["Solid Reactive Multi Nexus", 40],
+                  ["Spash", 41],
+                  ["Multi Splash", 42],
+                  ["Solid Splash", 43],
+                  ["Solid Multi Splash", 44]
+                ]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Effect Speed",
+                "type": "range",
+                "options": [0, 255],
+                "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              },
+              {
+                "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+                "label": "Color",
+                "type": "color",
+                "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "matrix": { "rows": 6, "cols": 21 },
+    "customKeycodes":[
+      {"name":"RESET","title":"RESET EEPROM","shortName":"RESET"}
+    ],
+    "layouts": {
+      "keymap":[
+        [
+          {
+            "c": "#777777"
+          },
+          "0,0",
+          {
+            "x": 1,
+            "c": "#aaaaaa"
+          },
+          "0,1",
+          "0,2",
+          "0,3",
+          "0,4",
+          {
+            "x": 0.5
+          },
+          "0,5",
+          "0,6",
+          "0,7",
+          "0,8",
+          {
+            "x": 0.5
+          },
+          "0,9",
+          "0,10",
+          "0,11",
+          "0,12",
+          {
+            "x": 0.25
+          },
+          "0,14",
+          "0,15",
+          "0,16",
+          {
+            "x": 0.25
+          },
+          "0,17",
+          "0,18",
+          "0,19",
+          "0,20"
+        ],
+        [
+          {
+            "y": 0.25,
+            "c": "#cccccc"
+          },
+          "1,0",
+          "1,1",
+          "1,2",
+          "1,3",
+          "1,4",
+          "1,5",
+          "1,6",
+          "1,7",
+          "1,8",
+          "1,9",
+          "1,10",
+          "1,11",
+          "1,12",
+          {
+            "c": "#aaaaaa",
+            "w": 2
+          },
+          "1,13",
+          {
+            "x": 0.25
+          },
+          "1,14",
+          "1,15",
+          "1,16",
+          {
+            "x": 0.25
+          },
+          "1,17",
+          "1,18",
+          "1,19",
+          "1,20"
+        ],
+        [
+          {
+            "w": 1.5
+          },
+          "2,0",
+          {
+            "c": "#cccccc"
+          },
+          "2,1",
+          "2,2",
+          "2,3",
+          "2,4",
+          "2,5",
+          "2,6",
+          "2,7",
+          "2,8",
+          "2,9",
+          "2,10",
+          "2,11",
+          "2,12",
+          {
+            "w": 1.5
+          },
+          "2,13",
+          {
+            "x": 0.25,
+            "c": "#aaaaaa"
+          },
+          "2,14",
+          "2,15",
+          "2,16",
+          {
+            "x": 0.25,
+            "c": "#cccccc"
+          },
+          "2,17",
+          "2,18",
+          "2,19",
+          {
+            "c": "#aaaaaa",
+            "h": 2
+          },
+          "2,20"
+        ],
+        [
+          {
+            "w": 1.75
+          },
+          "3,0",
+          {
+            "c": "#cccccc"
+          },
+          "3,1",
+          "3,2",
+          "3,3",
+          "3,4",
+          "3,5",
+          "3,6",
+          "3,7",
+          "3,8",
+          "3,9",
+          "3,10",
+          "3,11",
+          {
+            "c": "#777777",
+            "w": 2.25
+          },
+          "3,13",
+          {
+            "x": 3.5,
+            "c": "#cccccc"
+          },
+          "3,17",
+          "3,18",
+          "3,19"
+        ],
+        [
+          {
+            "c": "#aaaaaa",
+            "w": 2.25
+          },
+          "4,0",
+          {
+            "c": "#cccccc"
+          },
+          "4,1",
+          "4,2",
+          "4,3",
+          "4,4",
+          "4,5",
+          "4,6",
+          "4,7",
+          "4,8",
+          "4,9",
+          "4,10",
+          {
+            "c": "#aaaaaa",
+            "w": 2.75
+          },
+          "4,13",
+          {
+            "x": 1.25,
+            "c": "#777777"
+          },
+          "4,15",
+          {
+            "x": 1.25,
+            "c": "#cccccc"
+          },
+          "4,17",
+          "4,18",
+          "4,19",
+          {
+            "c": "#777777",
+            "h": 2
+          },
+          "4,20"
+        ],
+        [
+          {
+            "c": "#aaaaaa",
+            "w": 1.25
+          },
+          "5,0",
+          {
+            "w": 1.25
+          },
+          "5,1",
+          {
+            "w": 1.25
+          },
+          "5,2",
+          {
+            "c": "#777777",
+            "w": 6.25
+          },
+          "5,5",
+          {
+            "c": "#aaaaaa",
+            "w": 1.25
+          },
+          "5,9",
+          {
+            "w": 1.25
+          },
+          "5,10",
+          {
+            "w": 1.25
+          },
+          "5,11",
+          {
+            "w": 1.25
+          },
+          "5,13",
+          {
+            "x": 0.25,
+            "c": "#777777"
+          },
+          "5,14",
+          "5,15",
+          "5,16",
+          {
+            "x": 0.25,
+            "c": "#cccccc",
+            "w": 2
+          },
+          "5,18",
+          "5,19"
+        ]
+      ]
+    }
+  }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Adds json file for Monsgeek M5 keyboard. I've been using the keymap for over a year without issue.
<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/24957
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
https://github.com/the-via/qmk_userspace_via/pull/65
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
