### PR TITLE
[VIA] Update List of Lighting Modes for Monsgeek M5

### DIFF
--- a/v3/monsgeek/m5/m5.json
+++ b/v3/monsgeek/m5/m5.json
@@ -196,7 +196,8 @@
                 ],
                 [
                   "Solid Reactive Nexus",
-                  39],
+                  39
+                ],
                 [
                   "Solid Reactive Multi Nexus",
                   40

--- a/v3/monsgeek/m5/m5.json
+++ b/v3/monsgeek/m5/m5.json
@@ -39,182 +39,182 @@
               ],
               "options": [
                 [
-                  "ALL OFF",
+                  "All Off",
                   0
                 ],
                 [
-                  "SOLID COLOR",
+                  "Solid Color",
                   1
                 ],
                 [
-                  "ALPHAS MODS",
+                  "Alphas Mods",
                   2
                 ],
                 [
-                  "GRADIENT UP/DOWN",
+                  "Gradient Up/Down",
                   3
                 ],
                 [
-                  "GRADIENT LEFT/RIGHT",
+                  "Gradient Left/Right",
                   4
                 ],
                 [
-                  "BREATHING",
+                  "Breathing",
                   5
                 ],
                 [
-                  "BAND SAT.",
+                  "Band Sat.",
                   6
                 ],
                 [
-                  "BAND VAL.",
+                  "Band Val.",
                   7
                 ],
                 [
-                  "PINWHEEL SAT.",
+                  "Pinwheel Sat.",
                   8
                 ],
                 [
-                  "PINWHEEL VAL.",
+                  "Pinwheel Val.",
                   9
                 ],
                 [
-                  "SPIRAL SAT.",
+                  "Spiral Sat.",
                   10
                 ],
                 [
-                  "SPIRAL VAL.",
+                  "Spiral Val.",
                   11
                 ],
                 [
-                  "CYCLE ALL",
+                  "Cycle All",
                   12
                 ],
                 [
-                  "CYCLE LEFT/RIGHT",
+                  "Cycle Left/Right",
                   13
                 ],
                 [
-                  "CYCLE UP/DOWN",
+                  "Cycle Up/Down",
                   14
                 ],
                 [
-                  "RAINBOW MOVING CHEVRON",
+                  "Rainbow Moving Chevron",
                   15
                 ],
                 [
-                  "CYCLE OUT/IN",
+                  "Cycle Out/In",
                   16
                 ],
                 [
-                  "CYCLE OUT/IN DUAL",
+                  "Cycle Out/In Dual",
                   17
                 ],
                 [
-                  "CYCLE PINWHEEL",
+                  "Cycle Pinwheel",
                   18
                 ],
                 [
-                  "CYCLE SPIRAL",
+                  "Cycle Spiral",
                   19
                 ],
                 [
-                  "DUAL BEACON",
+                  "Dual Beacon",
                   20
                 ],
                 [
-                  "RAINBOW BEACON",
+                  "Rainbow Beacon",
                   21
                 ],
                 [
-                  "RAINBOW PINWHEELS",
+                  "Rainbow Pinwheels",
                   22
                 ],
                 [
-                  "RAINDROPS",
+                  "Raindrops",
                   23
                 ],
                 [
-                  "JELLYBEAN RAINDROPS",
+                  "Jellybean Raindrops",
                   24
                 ],
                 [
-                  "HUE BREATHING",
+                  "Hue Breathing",
                   25
                 ],
                 [
-                  "HUE PENDULUM",
+                  "Hue Pendulum",
                   26
                 ],
                 [
-                  "HUE WAVE",
+                  "Hue Wave",
                   27
                 ],
                 [
-                  "PIXEL RAIN",
+                  "Pixel Rain",
                   28
                 ],
                 [
-                  "PIXEL FLOW",
+                  "Pixel Flow",
                   29
                 ],
                 [
-                  "PIXEL FRACTAL",
+                  "Pixel Fractal",
                   30
                 ],
                 [
-                  "TYPING HEATMAP",
+                  "Typing Heatmap",
                   31
                 ],
                 [
-                  "DIGITAL RAIN",
+                  "Digital Rain",
                   32
                 ],
                 [
-                  "SOLID REACTIVE SIMPLE",
+                  "Solid Reactive Simple",
                   33
                 ],
                 [
-                  "SOLID REACTIVE",
+                  "Solid Reactive",
                   34
                 ],
                 [
-                  "SOLID REACTIVE WIDE",
+                  "Solid Reactive Wide",
                   35
                 ],
                 [
-                  "SOLID REACTIVE MULTI WIDE",
+                  "Solid Reactive Multi Wide",
                   36
                 ],
                 [
-                  "SOLID REACTIVE CROSS",
+                  "Solid Reactive Cross",
                   37
                 ],
                 [
-                  "SOLID REACTIVE MULTI CROSS",
+                  "Solid Reactive Multi Cross",
                   38
                 ],
                 [
-                  "SOLID REACTIVE NEXUS",
+                  "Solid Reactive Nexus",
                   39],
                 [
-                  "SOLID REACTIVE MULTI NEXUS",
+                  "Solid Reactive Multi Nexus",
                   40
                 ],
                 [
-                  "SPASH",
+                  "Splash",
                   41
                 ],
                 [
-                  "MULTI SPLASH",
+                  "Multi Splash",
                   42
                 ],
                 [
-                  "SOLID SPLASH",
+                  "Solid Splash",
                   43
                 ],
                 [
-                  "SOLID MULTI SPLASH",
+                  "Solid Multi Splash",
                   44
                 ]
               ]

--- a/v3/monsgeek/m5/m5.json
+++ b/v3/monsgeek/m5/m5.json
@@ -39,80 +39,183 @@
               ],
               "options": [
                 [
-                  "All Off",
+                  "ALL OFF",
                   0
                 ],
                 [
-                  "SOLID_COLOR",
+                  "SOLID COLOR",
                   1
                 ],
                 [
-                  "BREATHING",
+                  "ALPHAS MODS",
                   2
                 ],
                 [
-                  "CYCLE_ALL",
+                  "GRADIENT UP/DOWN",
                   3
                 ],
                 [
-                  "CYCLE_LEFT_RIGHT",
+                  "GRADIENT LEFT/RIGHT",
                   4
                 ],
                 [
-                  "CYCLE_UP_DOWN",
+                  "BREATHING",
                   5
                 ],
                 [
-                  "RAINBOW_MOVING_CHEVRON",
+                  "BAND SAT.",
                   6
                 ],
                 [
-                  "CYCLE_OUT_IN",
+                  "BAND VAL.",
                   7
                 ],
                 [
-                  "CYCLE_OUT_IN_DUAL",
+                  "PINWHEEL SAT.",
                   8
                 ],
                 [
-                  "CYCLE_PINWHEEL",
+                  "PINWHEEL VAL.",
                   9
                 ],
                 [
-                  "CYCKE_SPIRAL",
+                  "SPIRAL SAT.",
                   10
                 ],
                 [
-                  "DUAL_BEACON",
+                  "SPIRAL VAL.",
                   11
                 ],
                 [
-                  "RAINBOW_BEACON",
+                  "CYCLE ALL",
                   12
                 ],
                 [
-                  "RAINDROPS",
+                  "CYCLE LEFT/RIGHT",
                   13
                 ],
                 [
-                  "TYPING_HEATMAP",
+                  "CYCLE UP/DOWN",
                   14
                 ],
                 [
-                  "SOLID_REACTIVE_SIMPLE",
+                  "RAINBOW MOVING CHEVRON",
                   15
                 ],
                 [
-                  "SOLID_REACTIVE",
+                  "CYCLE OUT/IN",
                   16
                 ],
                 [
-                  "SOLID_REACTIVE_NEXUS",
+                  "CYCLE OUT/IN DUAL",
                   17
                 ],
                 [
-                  "MATRIX_MULTISPLASH",
+                  "CYCLE PINWHEEL",
                   18
+                ],
+                [
+                  "CYCLE SPIRAL",
+                  19
+                ],
+                [
+                  "DUAL BEACON",
+                  20
+                ],
+                [
+                  "RAINBOW BEACON",
+                  21
+                ],
+                [
+                  "RAINBOW PINWHEELS",
+                  22
+                ],
+                [
+                  "RAINDROPS",
+                  23
+                ],
+                [
+                  "JELLYBEAN RAINDROPS",
+                  24
+                ],
+                [
+                  "HUE BREATHING",
+                  25
+                ],
+                [
+                  "HUE PENDULUM",
+                  26
+                ],
+                [
+                  "HUE WAVE",
+                  27
+                ],
+                [
+                  "PIXEL RAIN",
+                  28
+                ],
+                [
+                  "PIXEL FLOW",
+                  29
+                ],
+                [
+                  "PIXEL FRACTAL",
+                  30
+                ],
+                [
+                  "TYPING HEATMAP",
+                  31
+                ],
+                [
+                  "DIGITAL RAIN",
+                  32
+                ],
+                [
+                  "SOLID REACTIVE SIMPLE",
+                  33
+                ],
+                [
+                  "SOLID REACTIVE",
+                  34
+                ],
+                [
+                  "SOLID REACTIVE WIDE",
+                  35
+                ],
+                [
+                  "SOLID REACTIVE MULTI WIDE",
+                  36
+                ],
+                [
+                  "SOLID REACTIVE CROSS",
+                  37
+                ],
+                [
+                  "SOLID REACTIVE MULTI CROSS",
+                  38
+                ],
+                [
+                  "SOLID REACTIVE NEXUS",
+                  39],
+                [
+                  "SOLID REACTIVE MULTI NEXUS",
+                  40
+                ],
+                [
+                  "SPASH",
+                  41
+                ],
+                [
+                  "MULTI SPLASH",
+                  42
+                ],
+                [
+                  "SOLID SPLASH",
+                  43
+                ],
+                [
+                  "SOLID MULTI SPLASH",
+                  44
                 ]
               ]
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This PR updates the list of lighting modes available through VIA, for the Monsgeek M5, to all available through QMK/VIA.
<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/24981
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->
Map and rule here...
https://github.com/the-via/qmk_userspace_via/tree/main/keyboards/monsgeek/m5/keymaps/via
<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
