### PR TITLE
Ploopyco Trackball - Fix incorrectly declared number of cols

### DIFF
--- a/v3/ploopyco/trackball/trackball.json
+++ b/v3/ploopyco/trackball/trackball.json
@@ -4,7 +4,7 @@
   "productId": "0x5442",
   "matrix": {
     "rows": 1,
-    "cols": 6
+    "cols": 5
   },
   "customKeycodes": [
     {

--- a/v3/ploopyco/trackball/trackball_mini.json
+++ b/v3/ploopyco/trackball/trackball_mini.json
@@ -4,7 +4,7 @@
   "productId": "0x1EAB",
   "matrix": {
     "rows": 1,
-    "cols": 6
+    "cols": 5
   },
   "customKeycodes": [
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
On Ploopys Trackball (classic/classic 2), and Trackball Mini;  6 columns are declared in the via definitions but should be 5

As seen in qmk repo these have 5 direct pins, across 3 revisions of Classic;
- [rev1_004](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ploopyco/trackball/rev1_004/keyboard.json#L6)
- [rev1_005](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ploopyco/trackball/rev1_005/keyboard.json#L6)
- [rev1_007](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ploopyco/trackball/rev1_007/keyboard.json#L10)

and 2 revisions of Mini 
- [rev1_001](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ploopyco/trackball_mini/rev1_001/keyboard.json#L4)
- [rev1_002](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ploopyco/trackball_mini/rev1_002/keyboard.json#L4)

Tested on `trackball_mini` and on dev board flashed with `trackball` firmware.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
