### PR TITLE
update iris rev3 PID to match QMK, add rev1 definition

### DIFF
--- a/src/keebio/iris/iris-rev1.json
+++ b/src/keebio/iris/iris-rev1.json
@@ -1,7 +1,7 @@
 {
-  "name": "Iris Rev. 3",
+  "name": "Iris Rev. 1",
   "vendorId": "0xCB10",
-  "productId": "0x3256",
+  "productId": "0x1256",
   "matrix": {
     "rows": 10,
     "cols": 6

--- a/v3/keebio/iris/iris-rev1.json
+++ b/v3/keebio/iris/iris-rev1.json
@@ -1,12 +1,17 @@
 {
-  "name": "Iris Rev. 3",
+  "name": "Iris Rev. 1",
   "vendorId": "0xCB10",
-  "productId": "0x3256",
+  "productId": "0x1256",
   "matrix": {
     "rows": 10,
     "cols": 6
   },
-  "lighting": "qmk_backlight_rgblight",
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    "qmk_backlight_rgblight"
+  ],
   "layouts": {
     "keymap": [
       [

--- a/v3/keebio/iris/iris-rev3.json
+++ b/v3/keebio/iris/iris-rev3.json
@@ -1,7 +1,7 @@
 {
   "name": "Iris Rev. 3",
   "vendorId": "0xCB10",
-  "productId": "0x1256",
+  "productId": "0x3256",
   "matrix": {
     "rows": 10,
     "cols": 6


### PR DESCRIPTION
## Description

Update `productId` in `iris-rev3.json` to match the value in [QMK](https://github.com/qmk/qmk_firmware/blob/ebfa3cdd5c38d023ed4525e25004155aad7ad3e0/keyboards/keebio/iris/rev3/keyboard.json#L4)  and allow the current firmware hosted at [caniusevia](https://www.caniusevia.com/docs/download_firmware) to connect to the app, add rev1 definition `iris-rev1.json` to maintain compatibility as discussed in [discord](https://discord.com/channels/662383052223283234/1081746886056214671/1363318311122632975)

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/1863
https://github.com/qmk/qmk_firmware/pull/18080

## VIA Keymap Pull Request

https://github.com/the-via/qmk_userspace_via/commit/e93a90c5a0fcad7dbf0fc064410866280d29efea

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
