### PR TITLE
Add VIA support for Coban Pad 12A

### DIFF
--- a/v3/coban/pad12a/pad12a.json
+++ b/v3/coban/pad12a/pad12a.json
@@ -1,0 +1,13 @@
+{
+  "name": "Coban Pad 12A",
+  "vendorId": "0xCB3A",
+  "productId": "0xC12A",
+  "matrix": { "rows": 3, "cols": 4 },
+  "layouts": {
+      "keymap": [
+          ["0,0\n\n\n\n\n\n\n\n\ne0", "0,1", "0,2", "0,3"],
+          ["1,0", "1,1", "1,2", "1,3"],
+          ["2,0", "2,1", "2,2", "2,3"]
+        ]
+  }
+}


### PR DESCRIPTION
## Description

Add support for Coban Pad 12A

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

https://github.com/qmk/qmk_firmware/pull/25039

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
https://github.com/the-via/qmk_userspace_via/pull/80

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
