### PR TITLE
Fix hotdox76 lighting

### DIFF
--- a/v3/hotdox76v2/hotdox76v2.json
+++ b/v3/hotdox76v2/hotdox76v2.json
@@ -10,7 +10,7 @@
     "qmk_lighting"
   ],
   "menus": [
-    "qmk_rgblight"
+    "qmk_rgb_matrix"
   ],
   "layouts": {
     "keymap": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR tweaks the hotdox lighting entry to the correct value of `qmk_rgb_matrix` to enable lighting to work in the VIA app. Fixes [#hotdox](https://github.com/qmk/qmk_firmware/issues/21562)

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [X] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [X] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [X] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [X] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [X] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [X] I have tested this keyboard definition using VIA's "Design" tab.
- [X] I have tested this keyboard definition with firmware on a device.
- [X] I have assigned alpha keys and modifier keys with the correct colors.
- [X] The Vendor ID is not `0xFEED`
