### PR TITLE
Add support for ZeroPad

### DIFF
--- a/src/handwired/ZeroPad/via.json
+++ b/src/handwired/ZeroPad/via.json
@@ -1,0 +1,34 @@
+{
+    "name": "ZeroPad",
+    "vendorId": "0x5A50",
+    "productId": "0x0000",
+    "matrix": {
+        "rows": 3,
+        "cols": 3
+    },
+    "layouts": {
+        "keymap": [
+            [
+                { "matrix": [0, 0], "key": "" },
+                { "matrix": [0, 1], "key": "" },
+                { "matrix": [0, 2], "key": "" }
+            ],
+            [
+                { "matrix": [1, 0], "key": "" },
+                { "matrix": [1, 1], "key": "" },
+                { "matrix": [1, 2], "key": "" }
+            ],
+            [
+                { "matrix": [2, 0], "key": "" },
+                { "matrix": [2, 1], "key": "" },
+                { "matrix": [2, 2], "key": "" }
+            ]
+        ]
+    },
+    "layers": [
+        { "name": "Layer 0" },
+        { "name": "Layer 1" },
+        { "name": "Layer 2" },
+        { "name": "Layer 3" }
+    ]
+}

--- a/v3/handwired/ZeroPad/via.json
+++ b/v3/handwired/ZeroPad/via.json
@@ -1,0 +1,43 @@
+{
+    "name": "ZeroPad",
+    "vendorId": "0x5A50",
+    "productId": "0x0000",
+    "matrix": {
+      "rows": 3,
+      "cols": 3
+    },
+    "layouts": {
+      "keymap": [
+        [
+          "0,0",
+          "0,1",
+          "0,2"
+        ],
+        [
+          "1,0",
+          "1,1",
+          "1,2"
+        ],
+        [
+          "2,0",
+          "2,1",
+          "2,2"
+        ]
+      ]
+    },
+    "layers": [
+      {
+        "name": "Layer 0"
+      },
+      {
+        "name": "Layer 1"
+      },
+      {
+        "name": "Layer 2"
+      },
+      {
+        "name": "Layer 3"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
I want this keyboard to be approved and automatically recognized by via. I can already change keybinds on the web, but I want that it is automatically recognized and supported officially by via.

## QMK Pull Request
https://github.com/qmk/qmk_firmware/pull/24737
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
