### PR TITLE
Create AMX60

### DIFF
--- a/v3/AMX60
+++ b/v3/AMX60
@@ -1,0 +1,308 @@
+{
+  "name": "AMX80",
+  "vendorId": "0x1A86",
+  "productId": "0xFE00",
+    "matrix": {
+    "rows": 5,
+    "cols": 15
+  },
+  "customKeycodes": [
+    {"name": "Bluetooth Host 1", "title": "Bluetooth Host 1", "shortName": "BTH1"},
+    {"name": "Bluetooth Host 2", "title": "Bluetooth Host 2", "shortName": "BTH2"},
+    {"name": "Bluetooth Host 3", "title": "Bluetooth Host 3", "shortName": "BTH3"},
+    {"name": "usb mode", "title": "usb mode", "shortName": "USB"},
+    {"name": "2.4G mode", "title": "2.4G mode", "shortName": "2.4G"},
+    {"name": "Close RGB", "title": "Close RGB", "shortName": "cRGB"},
+    {"name": "Open RGB", "title": "Open RGB", "shortName": "oRGB"},
+    {"name": "Reset", "title": "Reset", "shortName": "Rst"},
+    {"name": "Clean EEPROM", "title": "Clean EEPROM", "shortName": "cEE"},
+    {"name": "Update", "title": "Update", "shortName": "Upda"},
+    {"name": "Clean Wireless", "title": "Clean Wireless", "shortName": "cWi"},
+    {"name": "Light+", "title": "Light+", "shortName": "RGB+"},
+    {"name": "Light-", "title": "Light-", "shortName": "RGB-"},
+    {"name": "Magnetic Force +", "title": "Magnetic Force +", "shortName": "MF+"},
+    {"name": "Magnetic Force -", "title": "Magnetic Force -", "shortName": "MF-"},
+    {"name": "Actuation Point +", "title": "Actuation Point +", "shortName": "AP+"},
+    {"name": "Actuation Point -", "title": "Actuation Point -", "shortName": "AP-"}
+  ],
+  
+  "menus": [
+    {
+      "label": "Configurations",
+      "content": [
+        {
+          "label": "Wireless",
+          "content": [
+            {
+              "showIf": "{id_Work_mode} == 1",
+              "label": "BLE Device",
+              "type": "dropdown",
+              "options": [
+                ["Device 0", 0],
+                ["Device 1", 1],
+                ["Device 2", 2]
+              ],
+              "content": ["id_BLE_device", 0, 1]
+            },
+            {
+              "label": "Work Mode",
+              "type": "dropdown",
+              "options": [
+                ["USB", 0],
+                ["BlueTooth", 1],
+                ["RF 2.4G", 2]
+              ],
+              "content": ["id_Work_mode", 0, 2]
+            }
+          ]
+        },
+        {
+          "label": "RGBType",
+          "content": [
+            {
+              "label": "Style",
+              "type": "dropdown",
+              "options": [
+                ["OFF", 0],
+                ["Rainbow", 1],
+                ["Breath", 2],
+                ["Marquee", 3],
+                ["Solid", 4],
+                ["Cycle", 5],
+                ["Meteor", 6]
+              ],
+              "content": ["id_LED_Style", 1, 1]
+            },
+            {
+              "label": "RGBBrightness",
+              "type": "range",
+              "options": [1, 128],
+              "content": ["id_LED_Brightness", 1, 2]
+            },
+            {
+              "showIf": "{id_LED_Style} > 6",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 3],
+              "content": ["id_rgblight_speed", 1, 3]
+            },
+            {
+              "showIf": "{id_LED_Style} == 4",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_rgblight_color", 1, 4]
+            }
+          ]
+        }
+
+      ]
+    }
+  ],
+
+  "layouts": {
+    "labels": [],
+    "keymap": [
+  [
+    {
+      "y": 1,
+      "x": 0.5,
+      "c": "#1c1a1a",
+      "t": "#820d0d"
+    },
+    "0,0",
+    {
+      "x": 0.25,
+      "c": "#cccccc",
+      "t": "#000000"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    {
+      "x": 9.5
+    },
+    "0,12",
+    "0,13",
+    {
+      "w": 2
+    },
+    "0,14"
+  ],
+  [
+    {
+      "x": 0.25
+    },
+    "1,0",
+    {
+      "x": 0.25,
+      "w": 1.5
+    },
+    "1,1",
+    "1,2",
+    {
+      "x": 10
+    },
+    "1,11",
+    "1,12",
+    "1,13",
+    {
+      "w": 1.5
+    },
+    "1,14"
+  ],
+  [
+    "2,0",
+    {
+      "x": 0.25,
+      "w": 1.75
+    },
+    "2,1",
+    "2,2",
+    {
+      "x": 10.5
+    },
+    "2,12",
+    "2,13",
+    {
+      "w": 2.25
+    },
+    "2,14"
+  ],
+  [
+    {
+      "x": 1,
+      "w": 2.25
+    },
+    "3,1",
+    "3,2",
+    {
+      "x": 10
+    },
+    "3,11",
+    "3,12",
+    "3,13",
+    {
+      "f": 1,
+      "w": 1.75
+    },
+    "3,14"
+  ],
+  [
+    {
+      "x": 1,
+      "f": 3,
+      "w": 1.25
+    },
+    "4,1",
+    {
+      "w": 1.25
+    },
+    "4,2",
+    {
+      "x": 11.75
+    },
+    "4,12",
+    "4,13",
+    "4,14"
+  ],
+  [
+    {
+      "r": 12,
+      "y": -6,
+      "x": 5.25
+    },
+    "0,4",
+    "0,5",
+    "0,6",
+    "0,7"
+  ],
+  [
+    {
+      "x": 4.75
+    },
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6"
+  ],
+  [
+    {
+      "x": 5
+    },
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6"
+  ],
+  [
+    {
+      "x": 5.5
+    },
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6"
+  ],
+  [
+    {
+      "x": 6,
+      "w": 1.25
+    },
+    "4,4",
+    {
+      "w": 2.25
+    },
+    "4,6"
+  ],
+  [
+    {
+      "r": -12,
+      "y": -1.25,
+      "x": 9
+    },
+    "0,8",
+    "0,9",
+    "0,10",
+    "0,11"
+  ],
+  [
+    {
+      "x": 8.5
+    },
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10"
+  ],
+  [
+    {
+      "x": 9
+    },
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11"
+  ],
+  [
+    {
+      "x": 8.5
+    },
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10"
+  ],
+  [
+    {
+      "x": 8.5,
+      "w": 2.75
+    },
+    "4,7",
+    {
+      "w": 1.25
+    },
+    "4,10"
+  ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
