### PR TITLE
Add Theseus75

### DIFF
--- a/v3/haverworks/theseus75/theseus75.json
+++ b/v3/haverworks/theseus75/theseus75.json
@@ -1,0 +1,486 @@
+{
+  "name": "Theseus75",
+  "vendorId": "0x6877",
+  "productId": "0x0001",
+  "matrix": {
+    "rows": 12,
+    "cols": 9
+  },
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "RGB Underglow",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Alphas Mods",
+                "Gradient Up/Down",
+                "Gradient Left/Right",
+                "Breathing",
+                "Band Sat.",
+                "Band Val.",
+                "Pinwheel Sat.",
+                "Pinwheel Val.",
+                "Spiral Sat.",
+                "Spiral Val.",
+                "Cycle All",
+                "Cycle Left/Right",
+                "Cycle Up/Down",
+                "Rainbow Moving Chevron",
+                "Cycle Out/In",
+                "Cycle Out/In Dual",
+                "Cycle Pinwheel",
+                "Cycle Spiral",
+                "Dual Beacon",
+                "Rainbow Beacon",
+                "Rainbow Pinwheels",
+                "Raindrops",
+                "Jellybean Raindrops",
+                "Hue Breathing",
+                "Hue Pendulum",
+                "Hue Wave",
+                "Pixel Rain",
+                "Pixel Flow",
+                "Pixel Fractal"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        },
+        {
+          "label": "Caps Indicator",
+          "content": [
+            {
+              "label": "Enabled",
+              "type": "toggle",
+              "content": ["id_caps_indicator_enabled", 0, 1]
+            },
+            {
+              "showIf": "{id_caps_indicator_enabled} != 0",
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_caps_indicator_brightness", 0, 2]
+            },
+            {
+              "showIf": "{id_caps_indicator_enabled} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_caps_indicator_color", 0, 3]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      "ISO Enter",
+      "Split Left Shift",
+      [
+        "Bottom Left Row",
+        "Space / 1.25u",
+        "1.25u / Space",
+        "Space / 1u (Tsangan)",
+        "1u / Space (Tsangan)"
+      ],
+      [
+        "Bottom Right Row",
+        "3x 1u",
+        "2x 1.5u"
+      ]
+    ],
+    "keymap": [
+      [
+        {
+          "c": "#aaaaaa",
+          "x": 2.5,
+          "y": 0.25
+        },
+        "0,0\n\n\n\n\n\n\n\n\ne0",
+        {
+          "c": "#777777",
+          "x": 0.5
+        },
+        "0,1",
+        {
+          "c": "#cccccc",
+          "x": 0.25
+        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        {
+          "c": "#aaaaaa",
+          "x": 0.25
+        },
+        "0,6",
+        "0,7",
+        {
+          "x": 1
+        },
+        "6,0",
+        "6,1",
+        {
+          "c": "#cccccc",
+          "x": 0.25
+        },
+        "6,2",
+        "6,3",
+        "6,4",
+        "6,5",
+        {
+          "c": "#aaaaaa",
+          "x": 0.25
+        },
+        "6,6",
+        {
+          "x": 0.5
+        },
+        "6,8\n\n\n\n\n\n\n\n\ne1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "y": 0.25
+        },
+        "1,0",
+        {
+          "c": "#cccccc",
+          "x": 0.5
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        {
+          "x": 1
+        },
+        "7,0",
+        "7,1",
+        "7,2",
+        "7,3",
+        "7,4",
+        "7,5",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "7,6\n\n\n0,0",
+        {
+          "x": 0.5
+        },
+        "7,8",
+        {
+          "x": 0.5
+        },
+        "7,6\n\n\n0,1",
+        "7,7\n\n\n0,1"
+      ],
+      [
+        {
+          "x": 2.5
+        },
+        "2,0",
+        {
+          "x": 0.5,
+          "w": 1.5
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        {
+          "x": 1
+        },
+        "8,0",
+        "8,1",
+        "8,2",
+        "8,3",
+        "8,4",
+        "8,5",
+        "8,6",
+        {
+          "w": 1.5
+        },
+        "8,7\n\n\n1,0",
+        {
+          "c": "#aaaaaa",
+          "x": 0.5
+        },
+        "8,8",
+        {
+          "c": "#777777",
+          "h": 2,
+          "h2": 1,
+          "w": 1.25,
+          "w2": 1.5,
+          "x": 1.25,
+          "x2": -0.25
+        },
+        "9,7\n\n\n1,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "x": 2.5
+        },
+        "3,0",
+        {
+          "w": 1.75,
+          "x": 0.5
+        },
+        "3,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        {
+          "x": 1
+        },
+        "9,0",
+        "9,1",
+        "9,2",
+        "9,3",
+        "9,4",
+        "9,5",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "9,7\n\n\n1,0",
+        {
+          "c": "#aaaaaa",
+          "x": 0.5
+        },
+        "9,8",
+        {
+          "c": "#cccccc",
+          "x": 0.25
+        },
+        "9,6\n\n\n1,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "4,1\n\n\n2,1",
+        "4,2\n\n\n2,1",
+        {
+          "x": 0.25
+        },
+        "4,0",
+        {
+          "w": 2.25,
+          "x": 0.5
+        },
+        "4,1\n\n\n2,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        {
+          "x": 1
+        },
+        "10,0",
+        "10,1",
+        "10,2",
+        "10,3",
+        "10,4",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "10,6",
+        {
+          "x": 1.5
+        },
+        "10,8"
+      ],
+      [
+        {
+          "c": "#777777",
+          "x": 19.25,
+          "y": -0.75
+        },
+        "10,7"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "x": 2.5,
+          "y": -0.25
+        },
+        "5,0",
+        {
+          "x": 0.5,
+          "w": 1.25
+        },
+        "5,1\n\n\n3,0",
+        {
+          "w": 1.25
+        },
+        "5,2\n\n\n3,0",
+        {
+          "w": 1.25
+        },
+        "5,3\n\n\n3,0",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "5,4\n\n\n3,0",
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "5,7\n\n\n3,0",
+        {
+          "c": "#cccccc",
+          "w": 2.75,
+          "x": 1
+        },
+        "11,1",
+        {
+          "c": "#aaaaaa"
+        },
+        "11,3\n\n\n4,0",
+        "11,4\n\n\n4,0",
+        "11,5\n\n\n4,0"
+      ],
+      [
+        {
+          "c": "#777777",
+          "x": 18.25,
+          "y": -0.75
+        },
+        "11,6",
+        "11,7",
+        "11,8"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25,
+          "x": 4
+        },
+        "5,1\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "5,2\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "5,3\n\n\n3,1",
+        {
+          "w": 1.25
+        },
+        "5,4\n\n\n3,1",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "5,7\n\n\n3,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5,
+          "x": 3.75
+        },
+        "11,3\n\n\n4,1",
+        {
+          "w": 1.5
+        },
+        "11,5\n\n\n4,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5,
+          "x": 4,
+          "y": 0.25
+        },
+        "5,1\n\n\n3,2",
+        "5,2\n\n\n3,2",
+        {
+          "w": 1.5
+        },
+        "5,3\n\n\n3,2",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "5,4\n\n\n3,2",
+        {
+          "c": "#aaaaaa"
+        },
+        "5,7\n\n\n3,2"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.5,
+          "x": 4,
+          "y": 0.25
+        },
+        "5,1\n\n\n3,3",
+        "5,2\n\n\n3,3",
+        {
+          "w": 1.5
+        },
+        "5,3\n\n\n3,3",
+        "5,4\n\n\n3,3",
+        {
+          "c": "#cccccc",
+          "w": 2.25
+        },
+        "5,7\n\n\n3,3"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Adds support for the [Theseus75](https://haver.works/theseus75) keyboard.

(Tagging @ebastler for visibility as co-author.)

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

https://github.com/qmk/qmk_firmware/pull/25457

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

https://github.com/the-via/qmk_userspace_via/pull/111

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
