### PR TITLE
Adding support for Franky36

### DIFF
--- a/v3/handwired/franky36/franky36.json
+++ b/v3/handwired/franky36/franky36.json
@@ -1,13 +1,12 @@
 {
   "name": "franky36",
+  "vendorId": "0x1209",
+  "productId": "0x3336",
   "matrix": {
-    "cols": 10,
-    "rows": 4
+    "rows": 4,
+    "cols": 10
   },
-  "vendorId": "1209",
-  "productId": "3336",
   "layouts": {
-    "labels": [],
     "keymap": [
       [
         {
@@ -216,3 +215,4 @@
     ]
   }
 }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Re added again after fixing VID/PID in the main QMK repo

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

https://github.com/qmk/qmk_firmware/pull/25029

VID/PID fix only PR: https://github.com/qmk/qmk_firmware/pull/25160

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

https://github.com/the-via/qmk_userspace_via/pull/110

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
