### PR TITLE
Add support for the Sofle Pico keyboard

### DIFF
--- a/v3/sofle_pico/sofle_pico.json
+++ b/v3/sofle_pico/sofle_pico.json
@@ -13,7 +13,6 @@
     "cols": 6
   },
   "layouts": {
-    "labels": [],
     "keymap": [
       [
         {


### PR DESCRIPTION
## Description

Adds Sofle Pico support. This sofle variant was designed specifically for the RP2040 and supports addtional features not found in the legacy Sofle variants.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

QMK PR: https://github.com/qmk/qmk_firmware/pull/25750

## VIA Keymap Pull Request

VIA userspace PR: https://github.com/the-via/qmk_userspace_via/pull/122

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
