### PR TITLE
Update olly's orion to include lighting keycodes in via's menu

### DIFF
--- a/v3/mechlovin/olly/olly_orion.json
+++ b/v3/mechlovin/olly/olly_orion.json
@@ -6,6 +6,7 @@
     "rows": 6,
     "cols": 17
   },
+  "keycodes": ["qmk_lighting"],
   "menus": [
     {
       "label": "Lighting",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
As per title.
<!--- Describe your changes in detail here. -->
NOTE: Kbd is already in QMK/VIA, this PR is just for adding menu.

## QMK Pull Request
ditto
<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request
ditto
<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
