### PR TITLE
Rename dnworks/sbl to dnworks/60percent

### DIFF
--- a/v3/dnworks/sbl/sbl.json
+++ b/v3/dnworks/sbl/sbl.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnworks SBL",
+  "name": "DN Sixty",
   "vendorId": "0x4C23",
   "productId": "0x2934",
   "matrix": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Modified display name from "dnworks sbl" to "DN Sixty" since firmware is reused across various 60%s.

## QMK Pull Request
https://github.com/qmk/qmk_firmware/pull/20652

## VIA Keymap Pull Request
https://github.com/qmk/qmk_firmware/pull/20652 (inherited during migration)

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
