### PR TITLE
Added safeguard for calibration elements

### DIFF
--- a/v3/cipulot/ec1_at/ec1_at.json
+++ b/v3/cipulot/ec1_at/ec1_at.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_23u/ec_23u.json
+++ b/v3/cipulot/ec_23u/ec_23u.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_60/ec_60.json
+++ b/v3/cipulot/ec_60/ec_60.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_60x/ec_60x.json
+++ b/v3/cipulot/ec_60x/ec_60x.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_65x/ec_65x.json
+++ b/v3/cipulot/ec_65x/ec_65x.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_660c/ec_660c.json
+++ b/v3/cipulot/ec_660c/ec_660c.json
@@ -148,12 +148,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_980c/ec_980c.json
+++ b/v3/cipulot/ec_980c/ec_980c.json
@@ -223,12 +223,14 @@
               "content": ["id_bottoming_calibration", 0, 20]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_980c/legacy_ec_980c.json
+++ b/v3/cipulot/ec_980c/legacy_ec_980c.json
@@ -176,12 +176,14 @@
               "content": ["id_bottoming_calibration", 0, 17]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 19]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_alice/ec_alice.json
+++ b/v3/cipulot/ec_alice/ec_alice.json
@@ -301,12 +301,14 @@
               "content": ["id_bottoming_calibration", 0, 20]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_alice/legacy_ec_alice.json
+++ b/v3/cipulot/ec_alice/legacy_ec_alice.json
@@ -281,12 +281,14 @@
               "content": ["id_bottoming_calibration", 0, 23]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 25]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_alveus/ec_alveus_1_0_0.json
+++ b/v3/cipulot/ec_alveus/ec_alveus_1_0_0.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_alveus/ec_alveus_1_2_0.json
+++ b/v3/cipulot/ec_alveus/ec_alveus_1_2_0.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_cloudnine/ec_cloudnine.json
+++ b/v3/cipulot/ec_cloudnine/ec_cloudnine.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_constellation/ec_constellation.json
+++ b/v3/cipulot/ec_constellation/ec_constellation.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_dolice/ec_dolice.json
+++ b/v3/cipulot/ec_dolice/ec_dolice.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_lily/ec_lily.json
+++ b/v3/cipulot/ec_lily/ec_lily.json
@@ -222,12 +222,14 @@
               "content": ["id_bottoming_calibration", 0, 20]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_menhir/ec_menhir.json
+++ b/v3/cipulot/ec_menhir/ec_menhir.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_minimi40/ec_minimi40_ortho.json
+++ b/v3/cipulot/ec_minimi40/ec_minimi40_ortho.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_minimi40/ec_minimi40_stagger.json
+++ b/v3/cipulot/ec_minimi40/ec_minimi40_stagger.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_ogr_65/ec_ogr_65.json
+++ b/v3/cipulot/ec_ogr_65/ec_ogr_65.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_ogr_frl/ec_ogr_frl.json
+++ b/v3/cipulot/ec_ogr_frl/ec_ogr_frl.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_pro2/ec_pro2.json
+++ b/v3/cipulot/ec_pro2/ec_pro2.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_prox/ec_prox_ansi_iso.json
+++ b/v3/cipulot/ec_prox/ec_prox_ansi_iso.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_prox/ec_prox_ansi_iso_jun.json
+++ b/v3/cipulot/ec_prox/ec_prox_ansi_iso_jun.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_prox/ec_prox_jis.json
+++ b/v3/cipulot/ec_prox/ec_prox_jis.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_split_60/ec_split_60.json
+++ b/v3/cipulot/ec_split_60/ec_split_60.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_theca/ec_theca.json
+++ b/v3/cipulot/ec_theca/ec_theca.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_tkl/ec_tkl.json
+++ b/v3/cipulot/ec_tkl/ec_tkl.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_tkl_x/ec_tkl_x.json
+++ b/v3/cipulot/ec_tkl_x/ec_tkl_x.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_typeb/ec_typeb.json
+++ b/v3/cipulot/ec_typeb/ec_typeb.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_typek/ec_typek_advanced.json
+++ b/v3/cipulot/ec_typek/ec_typek_advanced.json
@@ -301,12 +301,14 @@
               "content": ["id_bottoming_calibration", 0, 20]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_typek/legacy_ec_typek_advanced.json
+++ b/v3/cipulot/ec_typek/legacy_ec_typek_advanced.json
@@ -281,12 +281,14 @@
               "content": ["id_bottoming_calibration", 0, 23]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 25]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_typek/legacy_ec_typek_basic.json
+++ b/v3/cipulot/ec_typek/legacy_ec_typek_basic.json
@@ -221,12 +221,14 @@
               "content": ["id_bottoming_calibration", 0, 17]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 19]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_vero/ec_vero.json
+++ b/v3/cipulot/ec_vero/ec_vero.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/ec_virgo/ec_virgo.json
+++ b/v3/cipulot/ec_virgo/ec_virgo.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/hybrid_blue_ridge/hybrid_blue_ridge.json
+++ b/v3/cipulot/hybrid_blue_ridge/hybrid_blue_ridge.json
@@ -98,12 +98,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_1_0.json
+++ b/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_1_0.json
@@ -96,12 +96,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_2_0.json
+++ b/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_2_0.json
@@ -96,12 +96,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/hybrid_is0gr/hybrid_is0gr.json
+++ b/v3/cipulot/hybrid_is0gr/hybrid_is0gr.json
@@ -96,12 +96,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/hybrid_kenban_de_go/hybrid_kenban_de_go.json
+++ b/v3/cipulot/hybrid_kenban_de_go/hybrid_kenban_de_go.json
@@ -96,12 +96,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/hybrid_little_man_40/hybrid_little_man_40.json
+++ b/v3/cipulot/hybrid_little_man_40/hybrid_little_man_40.json
@@ -96,12 +96,14 @@
                   "content": ["id_bottoming_calibration", 0, 8]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Show Board Calibration Data",
                   "type": "button",
                   "options": [0],
                   "content": ["id_show_calibration_data", 0, 10]
                 },
                 {
+                  "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear Board Calibration Data",
                   "type": "button",
                   "options": [0],

--- a/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
+++ b/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/leila/ec_leila.json
+++ b/v3/cipulot/leila/ec_leila.json
@@ -222,12 +222,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/logos_mk1_wrk/logos_mk1_wrk_ec.json
+++ b/v3/cipulot/logos_mk1_wrk/logos_mk1_wrk_ec.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/mkn_60_ec/mnk_60_ec.json
+++ b/v3/cipulot/mkn_60_ec/mnk_60_ec.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/mnk_65_ec/mnk_65_ec.json
+++ b/v3/cipulot/mnk_65_ec/mnk_65_ec.json
@@ -82,12 +82,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],

--- a/v3/cipulot/rf_r1_8_9xu/rf_r1_8_9xu.json
+++ b/v3/cipulot/rf_r1_8_9xu/rf_r1_8_9xu.json
@@ -84,12 +84,14 @@
               "content": ["id_bottoming_calibration", 0, 8]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Show Board Calibration Data",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
+              "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear Board Calibration Data",
               "type": "button",
               "options": [0],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
