### PR TITLE
Add Keychron K8 Pro ANSI RGB V3 definition

### DIFF
--- a/v3/keychron/k8_pro/k8_pro_ansi_rgb.json
+++ b/v3/keychron/k8_pro/k8_pro_ansi_rgb.json
@@ -1,0 +1,356 @@
+{
+  "name": "Keychron K8 Pro ANSI RGB",
+  "vendorId": "0x3434",
+  "productId": "0x0280",
+  "matrix": {
+    "rows": 6,
+    "cols": 17
+  },
+  "customKeycodes": [
+    {
+      "name": "Left Option",
+      "title": "Left Option",
+      "shortName": "LOpt"
+    },
+    {
+      "name": "Right Option",
+      "title": "Right Option",
+      "shortName": "ROpt"
+    },
+    {
+      "name": "Left Cmd",
+      "title": "Left Command",
+      "shortName": "LCmd"
+    },
+    {
+      "name": "Right Cmd",
+      "title": "Right Command",
+      "shortName": "RCmd"
+    },
+    {
+      "name": "Misson Control",
+      "title": "Misson Control, availabe in macOS",
+      "shortName": "MCtrl"
+    },
+    {
+      "name": "Launch pad",
+      "title": "Launch pad, availabe in macOS",
+      "shortName": "LPad"
+    },
+    {
+      "name": "Task View",
+      "title": "Task View in Windows",
+      "shortName": "Task"
+    },
+    {
+      "name": "File Explorer",
+      "title": "File Explorer in Windows",
+      "shortName": "File"
+    },
+    {
+      "name": "Screen shot",
+      "title": "Screenshot in macOS",
+      "shortName": "SShot"
+    },
+    {
+      "name": "Cortana",
+      "title": "Cortana in Windows",
+      "shortName": "Cortana"
+    },
+    {
+      "name": "Siri",
+      "title": "Siri in macOS",
+      "shortName": "Siri"
+    },
+    {
+      "name": "Bluetooth Host 1",
+      "title": "Bluetooth Host 1",
+      "shortName": "BT1"
+    },
+    {
+      "name": "Bluetooth Host 2",
+      "title": "Bluetooth Host 2",
+      "shortName": "BT2"
+    },
+    {
+      "name": "Bluetooth Host 3",
+      "title": "Bluetooth Host 3",
+      "shortName": "BT3"
+    },
+    {
+      "name": "Battery Level",
+      "title": "Show battery level",
+      "shortName": "Batt"
+    }
+  ],
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["00. None", 0],
+                ["01. SOLID_COLOR", 1],
+                ["02. BREATHING", 2],
+                ["03. BAND_SPIRAL_VAL", 3],
+                ["04. CYCLE_ALL", 4],
+                ["05. CYCLE_LEFT_RIGHT", 5],
+                ["06. CYCLE_UP_DOWN", 6],
+                ["07. RAINBOW_MOVING_CHEVRON", 7],
+                ["08. CYCLE_OUT_IN", 8],
+                ["09. CYCLE_OUT_IN_DUAL", 9],
+                ["10. CYCLE_PINWHEEL", 10],
+                ["11. CYCLE_SPIRAL", 11],
+                ["12. DUAL_BEACON", 12],
+                ["13. RAINBOW_BEACON", 13],
+                ["14. JELLYBEAN_RAINDROPS", 14],
+                ["15. PIXEL_RAIN", 15],
+                ["16. TYPING_HEATMAP", 16],
+                ["17. DIGITAL_RAIN", 17],
+                ["18. REACTIVE_SIMPLE", 18],
+                ["19. REACTIVE_MULTIWIDE", 19],
+                ["20. REACTIVE_MULTINEXUS", 20],
+                ["21. SPLASH", 21],
+                ["22. SOLID_SPLASH", 22]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,0",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        {
+          "x": 0.5,
+          "c": "#aaaaaa"
+        },
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        {
+          "x": 0.5,
+          "c": "#cccccc"
+        },
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa"
+        },
+        "0,14",
+        "0,15",
+        "0,16"
+      ],
+      [
+        {
+          "y": 0.25,
+          "c": "#aaaaaa"
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "w": 2,
+          "c": "#aaaaaa"
+        },
+        "1,13",
+        {
+          "x": 0.25
+        },
+        "1,14",
+        "1,15",
+        "1,16"
+      ],
+      [
+        {
+          "w": 1.5,
+          "c": "#aaaaaa"
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        "2,12",
+        {
+          "w": 1.5,
+          "c": "#aaaaaa"
+        },
+        "2,13",
+        {
+          "x": 0.25
+        },
+        "2,14",
+        "2,15",
+        "2,16"
+      ],
+      [
+        {
+          "w": 1.75,
+          "c": "#aaaaaa"
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "w": 2.25,
+          "c": "#777777"
+        },
+        "3,13"
+      ],
+      [
+        {
+          "w": 2.25,
+          "c": "#aaaaaa"
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        "4,2",
+        "4,3",
+        "4,4",
+        "4,5",
+        "4,6",
+        "4,7",
+        "4,8",
+        "4,9",
+        "4,10",
+        "4,11",
+        {
+          "w": 2.75,
+          "c": "#aaaaaa"
+        },
+        "4,13",
+        {
+          "x": 1.25,
+          "c": "#cccccc"
+        },
+        "4,15"
+      ],
+      [
+        {
+          "w": 1.25,
+          "c": "#aaaaaa"
+        },
+        "5,0",
+        {
+          "w": 1.25
+        },
+        "5,1",
+        {
+          "w": 1.25
+        },
+        "5,2",
+        {
+          "w": 6.25,
+          "c": "#cccccc"
+        },
+        "5,6",
+        {
+          "w": 1.25,
+          "c": "#aaaaaa"
+        },
+        "5,10",
+        {
+          "w": 1.25
+        },
+        "5,11",
+        {
+          "w": 1.25
+        },
+        "5,12",
+        {
+          "w": 1.25,
+          "c": "#aaaaaa"
+        },
+        "5,13",
+        {
+          "x": 0.25,
+          "c": "#cccccc"
+        },
+        "5,14",
+        "5,15",
+        "5,16"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds a V3 definition for the Keychron K8 Pro ANSI RGB (`0x3434` / `0x0280`).

Current K8 Pro firmware reports VIA protocol >= 11, so usevia.app expects a V3 definition and requests `/definitions/v3/875823744.json`. Since only a V2 definition exists for this board, that request is answered by the SPA fallback (HTML with HTTP 200) and the app fails with **"Fetching v3 definition failed"** — the keyboard cannot be configured at all without manually loading a draft definition in the Design tab. This PR adds the missing V3 file so the board works out of the box again.

- `matrix`, `customKeycodes` and `layouts` are identical to the existing V2 definition (`src/keychron/k8_pro/ansi_rgb.json`).
- The Lighting menu mirrors `v3/keychron/c2_pro/c2_pro_ansi_rgb.json` (standard `id_qmk_rgb_matrix_*` channel, 3); the two boards expose an identical RGB effect list.
- `npm run build` passes locally and the built definition lands in `dist/v3/875823744.json`.

Only the ANSI RGB variant is included, as that is the hardware I can test on.

## QMK Pull Request

The K8 Pro is not in QMK master — like the other Keychron wireless boards, its source lives in [Keychron's fork](https://github.com/Keychron/qmk_firmware/tree/bluetooth_playground/keyboards/keychron/k8_pro). This board is already supported by this repository via its V2 definition, and Keychron wireless definitions have been accepted previously (#1735). This PR only adds the V3 counterpart of an already-supported board so that current firmware can load it.

## VIA Keymap Pull Request

N/A — no new keyboard is being added; this is the V3 counterpart of an existing supported board.

## Checklist

- [ ] The VIA support for this keyboard is **MERGED** in QMK master — N/A, Keychron wireless board (see above)
- [ ] VIA keymap is **MERGED** in VIA userspace master — N/A (see above)
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab, on a physical K8 Pro ANSI RGB (authentication, keymap editing and remapping verified working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)