### PR TITLE
Update for testing new systems

### DIFF
--- a/v3/cipulot/ec1_at/ec1_at.json
+++ b/v3/cipulot/ec1_at/ec1_at.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 21
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_23u/ec_23u.json
+++ b/v3/cipulot/ec_23u/ec_23u.json
@@ -6,11 +6,163 @@
     "rows": 4,
     "cols": 6
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_60/ec_60.json
+++ b/v3/cipulot/ec_60/ec_60.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_60x/ec_60x.json
+++ b/v3/cipulot/ec_60x/ec_60x.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_60x/ec_60x_joker.json
+++ b/v3/cipulot/ec_60x/ec_60x_joker.json
@@ -1,0 +1,430 @@
+{
+  "name": "EC 60X JOKER",
+  "vendorId": "0x6369",
+  "productId": "0x6BF6",
+  "matrix": {
+    "rows": 5,
+    "cols": 15
+  },
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    "qmk_rgblight",
+    {
+      "label": "Switch Configuration",
+      "content": [
+        {
+          "label": "Actuation",
+          "content": [
+            {
+              "label": "Mode",
+              "type": "dropdown",
+              "options": ["APC", "Rapid Trigger"],
+              "content": ["id_actuation_mode", 0, 1]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_0_actuation_threshold", 0, 2]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_0_release_threshold", 0, 3]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_mode_1_initial_deadzone_offset", 0, 5]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_mode_1_actuation_offset", 0, 6]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_mode_1_release_offset", 0, 7]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Calibration",
+          "content": [
+            {
+              "label": "Board Calibration",
+              "type": "toggle",
+              "content": ["id_bottoming_calibration", 0, 8]
+            },
+            {
+              "label": "Noise Floor Calibration (DO NOT PRESS ANY KEY WHILE CLICKING)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_noise_floor_calibration", 0, 9]
+            },
+            {
+              "label": "Print calibration data to console",
+              "type": "button",
+              "options": [0],
+              "content": ["id_show_calibration_data", 0, 10]
+            },
+            {
+              "label": "Clear bottom-out calibration data",
+              "type": "button",
+              "options": [0],
+              "content": ["id_clear_bottoming_calibration_data", 0, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Gaming Features",
+      "content": [
+        {
+          "label": "SOCD",
+          "content": [
+            {
+              "label": "Enable Pair #1",
+              "type": "toggle",
+              "content": ["id_socd_pair_1_enabled", 0, 12]
+            },
+            {
+              "showIf": "{id_socd_pair_1_enabled} == 1",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 13]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 14]
+                },
+                {
+                  "label": "Pair #1 Mode",
+                  "type": "dropdown",
+                  "options": [
+                    ["Last Priority", 1],
+                    ["Neutral", 2],
+                    ["First Key Priority", 3],
+                    ["Second Key Priority", 4]
+                  ],
+                  "content": ["id_socd_pair_1_mode", 0, 15]
+                }
+              ]
+            },
+            {
+              "label": "Enable Pair #2",
+              "type": "toggle",
+              "content": ["id_socd_pair_2_enabled", 0, 16]
+            },
+            {
+              "showIf": "{id_socd_pair_2_enabled} == 1",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 17]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 18]
+                },
+                {
+                  "label": "Pair #2 Mode",
+                  "type": "dropdown",
+                  "options": [
+                    ["Last Priority", 1],
+                    ["Neutral", 2],
+                    ["First Key Priority", 3],
+                    ["Second Key Priority", 4]
+                  ],
+                  "content": ["id_socd_pair_2_mode", 0, 19]
+                }
+              ]
+            },
+            {
+              "label": "Enable Pair #3",
+              "type": "toggle",
+              "content": ["id_socd_pair_3_enabled", 0, 20]
+            },
+            {
+              "showIf": "{id_socd_pair_3_enabled} == 1",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 21]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 22]
+                },
+                {
+                  "label": "Pair #3 Mode",
+                  "type": "dropdown",
+                  "options": [
+                    ["Last Priority", 1],
+                    ["Neutral", 2],
+                    ["First Key Priority", 3],
+                    ["Second Key Priority", 4]
+                  ],
+                  "content": ["id_socd_pair_3_mode", 0, 23]
+                }
+              ]
+            },
+            {
+              "label": "Enable Pair #4",
+              "type": "toggle",
+              "content": ["id_socd_pair_4_enabled", 0, 24]
+            },
+            {
+              "showIf": "{id_socd_pair_4_enabled} == 1",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 25]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 26]
+                },
+                {
+                  "label": "Pair #4 Mode",
+                  "type": "dropdown",
+                  "options": [
+                    ["Last Priority", 1],
+                    ["Neutral", 2],
+                    ["First Key Priority", 3],
+                    ["Second Key Priority", 4]
+                  ],
+                  "content": ["id_socd_pair_4_mode", 0, 27]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "labels": [
+      "Split Backspace",
+      "Split Left Shift",
+      ["Right Shift", "Unified", "1.75U | 1U", "1U | 1.75U"],
+      "ISO"
+    ],
+    "keymap": [
+      [
+        {
+          "x": 2.5
+        },
+        "0,0",
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,14\n\n\n0,0",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "0,13\n\n\n0,1",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,14\n\n\n0,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "1,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13\n\n\n3,0",
+        {
+          "x": 1.75,
+          "c": "#777777",
+          "w": 1.25,
+          "h": 2,
+          "w2": 1.5,
+          "h2": 1,
+          "x2": -0.25
+        },
+        "1,14\n\n\n3,1"
+      ],
+      [
+        {
+          "x": 2.5,
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "2,13\n\n\n3,0",
+        {
+          "x": 0.75,
+          "c": "#cccccc"
+        },
+        "2,12\n\n\n3,1"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.25
+        },
+        "3,0\n\n\n1,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,1\n\n\n1,1",
+        {
+          "x": 0.25,
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "3,0\n\n\n1,0",
+        {
+          "c": "#cccccc"
+        },
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        "3,11",
+        {
+          "c": "#aaaaaa",
+          "w": 2.75
+        },
+        "3,13\n\n\n2,0",
+        {
+          "x": 0.25,
+          "w": 1.75
+        },
+        "3,12\n\n\n2,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,14\n\n\n2,1",
+        {
+          "x": 0.25
+        },
+        "3,12\n\n\n2,2",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "3,13\n\n\n2,2"
+      ],
+      [
+        {
+          "x": 2.5,
+          "w": 1.5
+        },
+        "4,0",
+        "4,1",
+        {
+          "w": 1.5
+        },
+        "4,2",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6",
+        {
+          "c": "#aaaaaa"
+        },
+        "4,10",
+        "4,11",
+        "4,12",
+        "4,13"
+      ]
+    ]
+  }
+}

--- a/v3/cipulot/ec_60x/ec_60x_matrix.json
+++ b/v3/cipulot/ec_60x/ec_60x_matrix.json
@@ -6,6 +6,158 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
@@ -150,7 +302,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -165,7 +317,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -179,7 +331,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 14]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -204,19 +356,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 17]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 18]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 19]
@@ -241,14 +393,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 23]
@@ -258,7 +410,7 @@
       ]
     },
     {
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -376,10 +528,1164 @@
       ]
     },
     {
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 2",
@@ -389,18 +1695,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 2",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 39]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 36]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 37]

--- a/v3/cipulot/ec_65x/ec_65x.json
+++ b/v3/cipulot/ec_65x/ec_65x.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_660c/ec_660c.json
+++ b/v3/cipulot/ec_660c/ec_660c.json
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -89,7 +89,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -103,7 +103,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -128,19 +128,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -165,14 +165,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -183,7 +183,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -301,11 +301,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -315,18 +1469,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 31]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_980c/ec_980c.json
+++ b/v3/cipulot/ec_980c/ec_980c.json
@@ -6,6 +6,158 @@
     "rows": 6,
     "cols": 19
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     {
@@ -149,7 +301,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -164,7 +316,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -178,7 +330,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 14]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -203,19 +355,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 17]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 18]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 19]
@@ -240,14 +392,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 23]
@@ -257,7 +409,7 @@
       ]
     },
     {
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -375,11 +527,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -389,18 +1695,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 39]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 36]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 37]

--- a/v3/cipulot/ec_alveus/ec_alveus_1_0_0.json
+++ b/v3/cipulot/ec_alveus/ec_alveus_1_0_0.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_alveus/ec_alveus_1_2_0.json
+++ b/v3/cipulot/ec_alveus/ec_alveus_1_2_0.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_bevel_proto/ec_bevel_proto.json
+++ b/v3/cipulot/ec_bevel_proto/ec_bevel_proto.json
@@ -1,7 +1,7 @@
 {
-  "name": "EC Alice",
+  "name": "EC Bevel Proto",
   "vendorId": "0x6369",
-  "productId": "0x6BF9",
+  "productId": "0x6C03",
   "matrix": {
     "rows": 5,
     "cols": 15
@@ -160,224 +160,7 @@
   ],
   "keycodes": ["qmk_lighting"],
   "menus": [
-    {
-      "label": "Lighting",
-      "content": [
-        {
-          "label": "Underglow",
-          "content": [
-            {
-              "label": "Brightness",
-              "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_brightness", 2, 1]
-            },
-            {
-              "label": "Effect",
-              "type": "dropdown",
-              "content": ["id_qmk_rgblight_effect", 2, 2],
-              "options": [
-                ["Solid Color", 1],
-                ["Breathing 1", 2],
-                ["Breathing 2", 3],
-                ["Breathing 3", 4],
-                ["Breathing 4", 5],
-                ["Rainbow Mood 1", 6],
-                ["Rainbow Mood 2", 7],
-                ["Rainbow Mood 3", 8],
-                ["Rainbow Swirl 1", 9],
-                ["Rainbow Swirl 2", 10],
-                ["Rainbow Swirl 3", 11],
-                ["Rainbow Swirl 4", 12],
-                ["Rainbow Swirl 5", 13],
-                ["Rainbow Swirl 6", 14],
-                ["Snake 1", 15],
-                ["Snake 2", 16],
-                ["Snake 3", 17],
-                ["Snake 4", 18],
-                ["Snake 5", 19],
-                ["Snake 6", 20],
-                ["Knight 1", 21],
-                ["Knight 2", 22],
-                ["Knight 3", 23],
-                ["Christmas", 24],
-                ["Gradient 1", 25],
-                ["Gradient 2", 26],
-                ["Gradient 3", 27],
-                ["Gradient 4", 28],
-                ["Gradient 5", 29],
-                ["Gradient 6", 30],
-                ["Gradient 7", 31],
-                ["Gradient 8", 32],
-                ["Gradient 9", 33],
-                ["Gradient 10", 34],
-                ["RGB Test", 35],
-                ["Alternating", 36],
-                ["Twinkle 1", 37],
-                ["Twinkle 2", 38],
-                ["Twinkle 3", 39],
-                ["Twinkle 4", 40],
-                ["Twinkle 5", 41],
-                ["Twinkle 6", 42]
-              ]
-            },
-            {
-              "showIf": "{id_qmk_rgblight_effect} != 0",
-              "label": "Effect Speed",
-              "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_effect_speed", 2, 3]
-            },
-            {
-              "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
-              "label": "Color",
-              "type": "color",
-              "content": ["id_qmk_rgblight_color", 2, 4]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Indicators",
-      "content": [
-        {
-          "label": "Left indicator",
-          "content": [
-            {
-              "label": "Enable Left Indicator",
-              "type": "toggle",
-              "content": ["id_ind3_enabled", 0, 9]
-            },
-            {
-              "showIf": "{id_ind3_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind3_brightness", 0, 10]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind3_color", 0, 11]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind3_func", 0, 12]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Central indicator",
-          "content": [
-            {
-              "label": "Enable Central Indicator",
-              "type": "toggle",
-              "content": ["id_ind2_enabled", 0, 5]
-            },
-            {
-              "showIf": "{id_ind2_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind2_brightness", 0, 6]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind2_color", 0, 7]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind2_func", 0, 8]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Right indicator",
-          "content": [
-            {
-              "label": "Enable Right Indicator",
-              "type": "toggle",
-              "content": ["id_ind1_enabled", 0, 1]
-            },
-            {
-              "showIf": "{id_ind1_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind1_brightness", 0, 2]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind1_color", 0, 3]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind1_func", 0, 4]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
+    "qmk_rgblight",
     {
       "label": "Switch Configuration",
       "content": [
@@ -388,7 +171,7 @@
               "label": "Mode",
               "type": "dropdown",
               "options": ["APC", "Rapid Trigger"],
-              "content": ["id_actuation_mode", 0, 13]
+              "content": ["id_actuation_mode", 0, 1]
             },
             {
               "showIf": "{id_actuation_mode} == 0",
@@ -405,7 +188,7 @@
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_actuation_threshold", 0, 14]
+                  "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
                   "label": "Release threshold (1-1023)",
@@ -419,13 +202,13 @@
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_release_threshold", 0, 15]
+                  "content": ["id_apc_release_threshold", 0, 3]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 16]
+                  "content": ["id_save_threshold_data", 0, 4]
                 }
               ]
             },
@@ -436,25 +219,25 @@
                   "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
-                  "content": ["id_rt_initial_deadzone_offset", 0, 17]
+                  "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
                   "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_actuation_offset", 0, 18]
+                  "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
                   "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_release_offset", 0, 19]
+                  "content": ["id_rt_release_offset", 0, 7]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 16]
+                  "content": ["id_save_threshold_data", 0, 4]
                 }
               ]
             }
@@ -466,21 +249,21 @@
             {
               "label": "Board Calibration",
               "type": "toggle",
-              "content": ["id_bottoming_calibration", 0, 20]
+              "content": ["id_bottoming_calibration", 0, 8]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
               "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
-              "content": ["id_show_calibration_data", 0, 22]
+              "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
               "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
-              "content": ["id_clear_bottoming_calibration_data", 0, 23]
+              "content": ["id_clear_bottoming_calibration_data", 0, 11]
             }
           ]
         }
@@ -502,7 +285,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_1_mode", 0, 24]
+              "content": ["id_socd_pair_1_mode", 0, 12]
             },
             {
               "showIf": "{id_socd_pair_1_mode} != 0",
@@ -510,12 +293,12 @@
                 {
                   "label": "Pair #1 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_1", 0, 25]
+                  "content": ["id_socd_pair_1_key_1", 0, 13]
                 },
                 {
                   "label": "Pair #1 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_2", 0, 26]
+                  "content": ["id_socd_pair_1_key_2", 0, 14]
                 }
               ]
             },
@@ -529,7 +312,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_2_mode", 0, 27]
+              "content": ["id_socd_pair_2_mode", 0, 15]
             },
             {
               "showIf": "{id_socd_pair_2_mode} != 0",
@@ -537,12 +320,12 @@
                 {
                   "label": "Pair #2 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 28]
+                  "content": ["id_socd_pair_2_key_1", 0, 16]
                 },
                 {
                   "label": "Pair #2 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 29]
+                  "content": ["id_socd_pair_2_key_2", 0, 17]
                 }
               ]
             },
@@ -556,7 +339,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_3_mode", 0, 30]
+              "content": ["id_socd_pair_3_mode", 0, 18]
             },
             {
               "showIf": "{id_socd_pair_3_mode} != 0",
@@ -564,12 +347,12 @@
                 {
                   "label": "Pair #3 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 31]
+                  "content": ["id_socd_pair_3_key_1", 0, 19]
                 },
                 {
                   "label": "Pair #3 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 32]
+                  "content": ["id_socd_pair_3_key_2", 0, 20]
                 }
               ]
             },
@@ -583,7 +366,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_4_mode", 0, 33]
+              "content": ["id_socd_pair_4_mode", 0, 21]
             },
             {
               "showIf": "{id_socd_pair_4_mode} != 0",
@@ -591,12 +374,12 @@
                 {
                   "label": "Pair #4 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 34]
+                  "content": ["id_socd_pair_4_key_1", 0, 22]
                 },
                 {
                   "label": "Pair #4 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 35]
+                  "content": ["id_socd_pair_4_key_2", 0, 23]
                 }
               ]
             }
@@ -605,7 +388,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "Tap Dance",
       "content": [
         {
@@ -1107,7 +889,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "Combos",
       "content": [
         {
@@ -1473,7 +1254,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "QMK Settings",
       "content": [
         {
@@ -1759,35 +1539,32 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
       "label": "System",
       "content": [
         {
           "label": "Maintenance",
           "content": [
             {
-              "showIf": "{id_firmware_version} >= 2",
               "label": "Firmware Version",
               "type": "label",
-              "content": ["id_firmware_version_text", 0, 38]
+              "content": ["id_firmware_version_text", 0, 26]
             },
             {
-              "showIf": "{id_firmware_version} >= 2",
               "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 39]
+              "content": ["id_firmware_build_text", 0, 27]
             },
             {
               "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 36]
+              "content": ["id_flash_mode", 0, 24]
             },
             {
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 37]
+              "content": ["id_factory_reset", 0, 25]
             }
           ]
         }
@@ -1795,287 +1572,196 @@
     }
   ],
   "layouts": {
-    "labels": [
-      "Split Backspace",
-      ["Right Shift", "HHKB", "Unified"],
-      ["Left Spacebar", "2U", "2.25U"]
-    ],
+    "labels": [["Bottom Row", "7U WK", "7U WKL", "7U HHKB"]],
     "keymap": [
       [
-        {
-          "y": 0.9,
-          "x": 0.55,
-          "c": "#777777"
-        },
-        "0,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 3.7,
-          "c": "#cccccc"
-        },
-        "0,2",
-        {
-          "x": 8.45
-        },
-        "0,11"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 1.7
-        },
-        "1,0",
+        "0,0",
         "0,1",
-        {
-          "x": 10.45
-        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
         "0,12",
+        "0,13",
         {
-          "c": "#aaaaaa",
-          "w": 2
+          "c": "#aaaaaa"
         },
-        "0,14\n\n\n0,0",
-        {
-          "x": 1.35
-        },
-        "0,13\n\n\n0,1",
-        "0,14\n\n\n0,1"
+        "0,14"
       ],
       [
         {
-          "y": -0.1,
-          "x": 0.35
-        },
-        "2,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 13,
-          "c": "#cccccc"
-        },
-        "1,11"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 1.5,
-          "c": "#aaaaaa",
           "w": 1.5
         },
-        "1,1",
+        "1,0",
         {
           "c": "#cccccc"
         },
+        "1,1",
         "1,2",
-        {
-          "x": 10
-        },
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
         "1,12",
-        "1,13",
         {
-          "c": "#aaaaaa",
           "w": 1.5
         },
         "1,14"
       ],
       [
         {
-          "y": -0.1,
-          "x": 0.15
-        },
-        "3,0"
-      ],
-      [
-        {
-          "y": -0.9,
-          "x": 1.3,
+          "c": "#aaaaaa",
           "w": 1.75
         },
-        "2,1",
+        "2,0",
         {
           "c": "#cccccc"
         },
+        "2,1",
         "2,2",
-        {
-          "x": 9.35
-        },
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
         "2,11",
-        "2,12",
         {
           "c": "#777777",
           "w": 2.25
         },
-        "2,14"
+        "2,13"
       ],
       [
         {
-          "x": 1.05,
           "c": "#aaaaaa",
           "w": 2.25
         },
-        "3,1",
+        "3,0",
         {
           "c": "#cccccc"
         },
         "3,2",
-        {
-          "x": 8.8
-        },
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
         "3,11",
-        "3,12",
         {
           "c": "#aaaaaa",
           "w": 1.75
         },
-        "3,13\n\n\n1,0",
-        "3,14\n\n\n1,0",
+        "3,12",
         {
-          "x": 0.5,
-          "w": 2.75
-        },
-        "3,13\n\n\n1,1"
-      ],
-      [
-        {
-          "x": 1.05,
-          "w": 1.5
-        },
-        "4,1",
-        {
-          "x": 13.55,
-          "w": 1.5
-        },
-        "4,14"
-      ],
-      [
-        {
-          "r": 12,
-          "y": -6,
-          "x": 5.05,
           "c": "#cccccc"
         },
-        "0,3",
-        "0,4",
-        "0,5",
-        "0,6"
+        "3,14"
       ],
       [
-        {
-          "x": 4.6
-        },
-        "1,3",
-        "1,4",
-        "1,5",
-        "1,6"
-      ],
-      [
-        {
-          "x": 4.85
-        },
-        "2,3",
-        "2,4",
-        "2,5",
-        "2,6"
-      ],
-      [
-        {
-          "x": 5.3
-        },
-        "3,3",
-        "3,4",
-        "3,5",
-        "3,6"
-      ],
-      [
-        {
-          "x": 6.6,
-          "w": 2
-        },
-        "4,5\n\n\n2,0",
         {
           "c": "#aaaaaa",
-          "w": 1.25
-        },
-        "4,6\n\n\n2,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 5.05,
           "w": 1.5
         },
-        "4,3"
-      ],
-      [
+        "4,0\n\n\n0,0",
+        "4,1\n\n\n0,0",
         {
-          "y": 0.35,
-          "x": 6.6,
+          "w": 1.5
+        },
+        "4,2\n\n\n0,0",
+        {
           "c": "#cccccc",
-          "w": 2.25
+          "w": 7
         },
-        "4,5\n\n\n2,1",
+        "4,6\n\n\n0,0",
         {
-          "c": "#aaaaaa"
-        },
-        "4,6\n\n\n2,1"
-      ],
-      [
-        {
-          "r": -12,
-          "y": -2.8,
-          "x": 8.45,
-          "c": "#cccccc"
-        },
-        "0,7",
-        "0,8",
-        "0,9",
-        "0,10"
-      ],
-      [
-        {
-          "x": 8.05
-        },
-        "1,7",
-        "1,8",
-        "1,9",
-        "1,10"
-      ],
-      [
-        {
-          "x": 8.2
-        },
-        "2,7",
-        "2,8",
-        "2,9",
-        "2,10"
-      ],
-      [
-        {
-          "x": 7.75
-        },
-        "3,7",
-        "3,8",
-        "3,9",
-        "3,10"
-      ],
-      [
-        {
-          "x": 7.75,
-          "w": 2.75
-        },
-        "4,8"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 10.55,
           "c": "#aaaaaa",
           "w": 1.5
         },
-        "4,10"
+        "4,11\n\n\n0,0",
+        "4,12\n\n\n0,0",
+        {
+          "w": 1.5
+        },
+        "4,14\n\n\n0,0"
+      ],
+      [
+        {
+          "y": 0.25,
+          "w": 1.5
+        },
+        "4,0\n\n\n0,1",
+        {
+          "d": true
+        },
+        "4,1\n\n\n0,1",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n0,1",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n0,1",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n0,1",
+        {
+          "d": true
+        },
+        "4,12\n\n\n0,1",
+        {
+          "w": 1.5
+        },
+        "4,14\n\n\n0,1"
+      ],
+      [
+        {
+          "y": 0.25,
+          "w": 1.5,
+          "d": true
+        },
+        "4,0\n\n\n0,2",
+        "4,1\n\n\n0,2",
+        {
+          "w": 1.5
+        },
+        "4,2\n\n\n0,2",
+        {
+          "c": "#cccccc",
+          "w": 7
+        },
+        "4,6\n\n\n0,2",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "4,11\n\n\n0,2",
+        "4,12\n\n\n0,2",
+        {
+          "w": 1.5,
+          "d": true
+        },
+        "4,14\n\n\n0,2"
       ]
     ]
   }

--- a/v3/cipulot/ec_cloudnine/ec_cloudnine.json
+++ b/v3/cipulot/ec_cloudnine/ec_cloudnine.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_constellation/ec_constellation.json
+++ b/v3/cipulot/ec_constellation/ec_constellation.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_dolice/ec_dolice.json
+++ b/v3/cipulot/ec_dolice/ec_dolice.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_lily/ec_lily.json
+++ b/v3/cipulot/ec_lily/ec_lily.json
@@ -6,6 +6,158 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
       "label": "Indicators",
@@ -148,7 +300,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -163,7 +315,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -177,7 +329,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 14]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -202,19 +354,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 17]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 18]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 19]
@@ -239,14 +391,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 23]
@@ -257,7 +409,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -375,11 +527,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -389,18 +1695,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 39]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 36]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 37]

--- a/v3/cipulot/ec_menhir/ec_menhir.json
+++ b/v3/cipulot/ec_menhir/ec_menhir.json
@@ -6,9 +6,161 @@
     "rows": 4,
     "cols": 12
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_minimi40/ec_minimi40_ortho.json
+++ b/v3/cipulot/ec_minimi40/ec_minimi40_ortho.json
@@ -6,9 +6,161 @@
     "rows": 12,
     "cols": 4
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_minimi40/ec_minimi40_stagger.json
+++ b/v3/cipulot/ec_minimi40/ec_minimi40_stagger.json
@@ -6,9 +6,161 @@
     "rows": 11,
     "cols": 4
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_ogr_65/ec_ogr_65.json
+++ b/v3/cipulot/ec_ogr_65/ec_ogr_65.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 18
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_ogr_frl/ec_ogr_frl.json
+++ b/v3/cipulot/ec_ogr_frl/ec_ogr_frl.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 18
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_pro2/ec_pro2.json
+++ b/v3/cipulot/ec_pro2/ec_pro2.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_prox/ec_prox_ansi_iso.json
+++ b/v3/cipulot/ec_prox/ec_prox_ansi_iso.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_prox/ec_prox_ansi_iso_jun.json
+++ b/v3/cipulot/ec_prox/ec_prox_ansi_iso_jun.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 2",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 2",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_prox/ec_prox_jis.json
+++ b/v3/cipulot/ec_prox/ec_prox_jis.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 14
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_split_60/ec_split_60.json
+++ b/v3/cipulot/ec_split_60/ec_split_60.json
@@ -6,11 +6,163 @@
     "rows": 10,
     "cols": 8
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_theca/ec_theca.json
+++ b/v3/cipulot/ec_theca/ec_theca.json
@@ -6,9 +6,161 @@
     "rows": 6,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_tkl/ec_tkl.json
+++ b/v3/cipulot/ec_tkl/ec_tkl.json
@@ -6,11 +6,163 @@
     "rows": 6,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_tkl_x/ec_tkl_x.json
+++ b/v3/cipulot/ec_tkl_x/ec_tkl_x.json
@@ -6,11 +6,163 @@
     "rows": 6,
     "cols": 18
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_typeb/ec_typeb.json
+++ b/v3/cipulot/ec_typeb/ec_typeb.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_typek/ec_typek_advanced.json
+++ b/v3/cipulot/ec_typek/ec_typek_advanced.json
@@ -6,6 +6,158 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     {
@@ -227,7 +379,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -242,7 +394,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -256,7 +408,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 14]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -281,19 +433,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 17]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 18]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 19]
@@ -318,14 +470,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 22]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 23]
@@ -335,7 +487,7 @@
       ]
     },
     {
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -453,11 +605,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -467,18 +1773,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 39]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 36]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 37]

--- a/v3/cipulot/ec_vero/ec_vero.json
+++ b/v3/cipulot/ec_vero/ec_vero.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/ec_virgo/ec_virgo.json
+++ b/v3/cipulot/ec_virgo/ec_virgo.json
@@ -6,9 +6,161 @@
     "rows": 6,
     "cols": 18
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/firmware_version_checker.py
+++ b/v3/cipulot/firmware_version_checker.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+from pathlib import Path
+from collections import defaultdict
+
+# Define the root directory
+ROOT_DIR = Path(__file__).parent
+
+# Regex pattern to find {id_firmware_version} comparisons
+# Matches patterns like: {id_firmware_version} >= 2, {id_firmware_version} <= 1, etc.
+FIRMWARE_PATTERN = r"\{id_firmware_version\}\s*([><=!]+)\s*(\d+)"
+
+
+def extract_firmware_values(file_path):
+    """
+    Extract all firmware version values from a JSON file.
+    Returns a list of tuples: (operator, value)
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            # Read the file as text to find all patterns
+            content = f.read()
+
+        # Find all matches
+        matches = re.findall(FIRMWARE_PATTERN, content)
+        return matches
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return []
+
+
+def get_highest_value(matches):
+    """
+    Extract the highest value from the comparisons.
+    For example, if we have >= 2 and <= 1, returns 2.
+    """
+    if not matches:
+        return None
+
+    values = [int(value) for _, value in matches]
+    return max(values) if values else None
+
+
+def main():
+    # Dictionary to store results
+    results = defaultdict(list)
+
+    # Walk through all directories
+    for root, dirs, files in os.walk(ROOT_DIR):
+        for file in files:
+            if file.endswith(".json"):
+                file_path = Path(root) / file
+
+                # Extract firmware version values
+                matches = extract_firmware_values(file_path)
+
+                if matches:
+                    highest_value = get_highest_value(matches)
+                    # Get relative path
+                    rel_path = file_path.relative_to(ROOT_DIR)
+
+                    results[str(rel_path)] = {
+                        "matches": matches,
+                        "highest_value": highest_value,
+                        "count": len(matches),
+                    }
+
+    # Print results in simple format
+    print("Board | Highest Firmware Version\n" + "-" * 60)
+
+    for file_path in sorted(results.keys()):
+        data = results[file_path]
+        highest = data["highest_value"]
+        print(f"{file_path} | {highest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/cipulot/hybrid_blue_ridge/hybrid_blue_ridge.json
+++ b/v3/cipulot/hybrid_blue_ridge/hybrid_blue_ridge.json
@@ -6,11 +6,163 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "Hybrid Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -36,7 +188,7 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -50,7 +202,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -67,7 +219,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
@@ -75,19 +227,19 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -96,7 +248,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -115,17 +267,17 @@
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Show Board Calibration Data",
+                  "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_show_calibration_data", 0, 10]
+                  "content": ["id_print_calibration_data", 0, 10]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Clear Board Calibration Data",
+                  "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottoming_calibration_data", 0, 11]
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
                 }
               ]
             }
@@ -135,7 +287,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -253,11 +405,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -267,18 +1573,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 28]
+              "content": ["id_firmware_build_date_text", 0, 28]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 25]
+              "content": ["id_enter_bootloader", 0, 25]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 26]

--- a/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_2_0.json
+++ b/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_2_0.json
@@ -6,9 +6,162 @@
     "rows": 5,
     "cols": 22
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
+  "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Hybrid Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -34,7 +187,7 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -48,7 +201,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -65,7 +218,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
@@ -73,19 +226,19 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -94,7 +247,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -113,17 +266,17 @@
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Show Board Calibration Data",
+                  "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_show_calibration_data", 0, 10]
+                  "content": ["id_print_calibration_data", 0, 10]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Clear Board Calibration Data",
+                  "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottoming_calibration_data", 0, 11]
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
                 }
               ]
             }
@@ -133,7 +286,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -251,10 +404,1165 @@
       ]
     },
     {
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Information",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -264,9 +1572,23 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 28]
+              "content": ["id_firmware_build_date_text", 0, 28]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Enter bootloader",
+              "type": "button",
+              "options": [0],
+              "content": ["id_enter_bootloader", 0, 25]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 26]
             }
           ]
         }

--- a/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_3_0.json
+++ b/v3/cipulot/hybrid_enso_e/hybrid_enso_e_1_3_0.json
@@ -1,10 +1,10 @@
 {
   "name": "Hybrid Enso-E",
   "vendorId": "0x6369",
-  "productId": "0x6BE8",
+  "productId": "0x6BFB",
   "matrix": {
     "rows": 5,
-    "cols": 14
+    "cols": 26
   },
   "customKeycodes": [
     {
@@ -158,33 +158,39 @@
       "shortName": "KEY\nLOCK"
     }
   ],
-  "keycodes": ["qmk_lighting"],
   "menus": [
     {
       "label": "Switch Configuration",
       "content": [
         {
-          "label": "Actuation",
+          "label": "General Board",
           "content": [
             {
+              "label": "Board Mode",
+              "type": "dropdown",
+              "options": ["Full EC", "Full MX", "Hybrid"],
+              "content": ["id_board_mode", 0, 109]
+            },
+            {
+              "showIf": "{id_board_mode} == 2",
               "label": "Switch Type",
               "type": "dropdown",
               "options": ["EC", "MX"],
-              "content": ["id_switch_type", 0, 12]
+              "content": ["id_switch_type", 0, 96]
             },
             {
-              "showIf": "{id_switch_type} == 0",
+              "showIf": "{id_board_mode} == 0 || ({id_board_mode} == 2 && {id_switch_type} == 0)",
               "content": [
                 {
                   "label": "Mode",
                   "type": "dropdown",
                   "options": ["APC", "Rapid Trigger"],
-                  "content": ["id_actuation_mode", 0, 1]
+                  "content": ["id_actuation_mode", 0, 85]
                 }
               ]
             },
             {
-              "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
+              "showIf": "({id_board_mode} == 0 && {id_actuation_mode} == 0) || ({id_board_mode} == 2 && {id_switch_type} == 0 && {id_actuation_mode} == 0)",
               "content": [
                 {
                   "label": "Actuation threshold (1-1023)",
@@ -193,12 +199,12 @@
                   "constraints": [
                     {
                       "operator": ">=",
-                      "reference": "id_apc_release_threshold",
+                      "reference": "id_mode_0_release_threshold",
                       "offset": 50,
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_actuation_threshold", 0, 2]
+                  "content": ["id_mode_0_actuation_threshold", 0, 86]
                 },
                 {
                   "label": "Release threshold (1-1023)",
@@ -207,76 +213,1168 @@
                   "constraints": [
                     {
                       "operator": "<=",
-                      "reference": "id_apc_actuation_threshold",
+                      "reference": "id_mode_0_actuation_threshold",
                       "offset": -50,
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_release_threshold", 0, 3]
+                  "content": ["id_mode_0_release_threshold", 0, 87]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_apply_thresholds", 0, 4]
+                  "content": ["id_save_threshold_data", 0, 88]
                 }
               ]
             },
             {
-              "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
+              "showIf": "({id_board_mode} == 0 && {id_actuation_mode} == 1) || ({id_board_mode} == 2 && {id_switch_type} == 0 && {id_actuation_mode} == 1)",
               "content": [
                 {
                   "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
-                  "content": ["id_rt_initial_deadzone_offset", 0, 5]
+                  "content": ["id_mode_1_initial_deadzone_offset", 0, 89]
                 },
                 {
                   "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_actuation_offset", 0, 6]
+                  "content": ["id_mode_1_actuation_offset", 0, 90]
                 },
                 {
                   "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_release_offset", 0, 7]
+                  "content": ["id_mode_1_release_offset", 0, 91]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_apply_thresholds", 0, 4]
+                  "content": ["id_save_threshold_data", 0, 88]
                 }
               ]
             }
           ]
         },
         {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Caps Key",
+          "content": [
+            {
+              "label": "Caps Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_1", 0, 1]
+            },
+            {
+              "showIf": "{id_switch_type_key_1} == 0",
+              "content": [
+                {
+                  "label": "Caps Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_1", 0, 2]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_1} == 0 && {id_actuation_mode_key_1} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_1",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_1", 0, 3]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_1",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_1", 0, 4]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_1} == 0 && {id_actuation_mode_key_1} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_1", 0, 5]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_1", 0, 6]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_1", 0, 7]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Left Shift Key",
+          "content": [
+            {
+              "label": "Left Shift Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_2", 0, 8]
+            },
+            {
+              "showIf": "{id_switch_type_key_2} == 0",
+              "content": [
+                {
+                  "label": "Left Shift Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_2", 0, 9]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_2} == 0 && {id_actuation_mode_key_2} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_2",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_2", 0, 10]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_2",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_2", 0, 11]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_2} == 0 && {id_actuation_mode_key_2} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_2", 0, 12]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_2", 0, 13]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_2", 0, 14]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right Shift Key",
+          "content": [
+            {
+              "label": "Right Shift Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_3", 0, 15]
+            },
+            {
+              "showIf": "{id_switch_type_key_3} == 0",
+              "content": [
+                {
+                  "label": "Right Shift Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_3", 0, 16]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_3} == 0 && {id_actuation_mode_key_3} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_3",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_3", 0, 17]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_3",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_3", 0, 18]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_3} == 0 && {id_actuation_mode_key_3} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_3", 0, 19]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_3", 0, 20]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_3", 0, 21]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right FN Key",
+          "content": [
+            {
+              "label": "Right FN Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_4", 0, 22]
+            },
+            {
+              "showIf": "{id_switch_type_key_4} == 0",
+              "content": [
+                {
+                  "label": "Right FN Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_4", 0, 23]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_4} == 0 && {id_actuation_mode_key_4} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_4",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_4", 0, 24]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_4",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_4", 0, 25]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_4} == 0 && {id_actuation_mode_key_4} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_4", 0, 26]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_4", 0, 27]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_4", 0, 28]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Left Mod 1 Key",
+          "content": [
+            {
+              "label": "Left Mod 1 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_5", 0, 29]
+            },
+            {
+              "showIf": "{id_switch_type_key_5} == 0",
+              "content": [
+                {
+                  "label": "Left Mod 1 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_5", 0, 30]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_5} == 0 && {id_actuation_mode_key_5} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_5",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_5", 0, 31]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_5",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_5", 0, 32]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_5} == 0 && {id_actuation_mode_key_5} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_5", 0, 33]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_5", 0, 34]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_5", 0, 35]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Left Mod 2 Key",
+          "content": [
+            {
+              "label": "Left Mod 2 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_6", 0, 36]
+            },
+            {
+              "showIf": "{id_switch_type_key_6} == 0",
+              "content": [
+                {
+                  "label": "Left Mod 2 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_6", 0, 37]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_6} == 0 && {id_actuation_mode_key_6} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_6",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_6", 0, 38]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_6",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_6", 0, 39]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_6} == 0 && {id_actuation_mode_key_6} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_6", 0, 40]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_6", 0, 41]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_6", 0, 42]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Left Spacebar 1 Key",
+          "content": [
+            {
+              "label": "Left Spacebar 1 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_7", 0, 43]
+            },
+            {
+              "showIf": "{id_switch_type_key_7} == 0",
+              "content": [
+                {
+                  "label": "Left Spacebar 1 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_7", 0, 44]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_7} == 0 && {id_actuation_mode_key_7} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_7",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_7", 0, 45]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_7",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_7", 0, 46]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_7} == 0 && {id_actuation_mode_key_7} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_7", 0, 47]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_7", 0, 48]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_7", 0, 49]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Left Spacebar 2 Key",
+          "content": [
+            {
+              "label": "Left Spacebar 2 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_8", 0, 50]
+            },
+            {
+              "showIf": "{id_switch_type_key_8} == 0",
+              "content": [
+                {
+                  "label": "Left Spacebar 2 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_8", 0, 51]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_8} == 0 && {id_actuation_mode_key_8} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_8",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_8", 0, 52]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_8",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_8", 0, 53]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_8} == 0 && {id_actuation_mode_key_8} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_8", 0, 54]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_8", 0, 55]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_8", 0, 56]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right Spacebar 1 Key",
+          "content": [
+            {
+              "label": "Right Spacebar 1 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_9", 0, 57]
+            },
+            {
+              "showIf": "{id_switch_type_key_9} == 0",
+              "content": [
+                {
+                  "label": "Right Spacebar 1 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_9", 0, 58]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_9} == 0 && {id_actuation_mode_key_9} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_9",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_9", 0, 59]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_9",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_9", 0, 60]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_9} == 0 && {id_actuation_mode_key_9} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_9", 0, 61]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_9", 0, 62]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_9", 0, 63]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right Spacebar 2 Key",
+          "content": [
+            {
+              "label": "Right Spacebar 2 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_10", 0, 64]
+            },
+            {
+              "showIf": "{id_switch_type_key_10} == 0",
+              "content": [
+                {
+                  "label": "Right Spacebar 2 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_10", 0, 65]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_10} == 0 && {id_actuation_mode_key_10} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_10",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_10", 0, 66]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_10",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_10", 0, 67]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_10} == 0 && {id_actuation_mode_key_10} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_10", 0, 68]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_10", 0, 69]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_10", 0, 70]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right Mod 1 Key",
+          "content": [
+            {
+              "label": "Right Mod 1 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_11", 0, 71]
+            },
+            {
+              "showIf": "{id_switch_type_key_11} == 0",
+              "content": [
+                {
+                  "label": "Right Mod 1 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_11", 0, 72]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_11} == 0 && {id_actuation_mode_key_11} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_11",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_11", 0, 73]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_11",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_11", 0, 74]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_11} == 0 && {id_actuation_mode_key_11} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_11", 0, 75]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_11", 0, 76]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_11", 0, 77]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 2",
+          "label": "Right Mod 2 Key",
+          "content": [
+            {
+              "label": "Right Mod 2 Key Switch Type",
+              "type": "dropdown",
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type_key_12", 0, 78]
+            },
+            {
+              "showIf": "{id_switch_type_key_12} == 0",
+              "content": [
+                {
+                  "label": "Right Mod 2 Key Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode_key_12", 0, 79]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_12} == 0 && {id_actuation_mode_key_12} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold_key_12",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold_key_12", 0, 80]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold_key_12",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold_key_12", 0, 81]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type_key_12} == 0 && {id_actuation_mode_key_12} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset_key_12", 0, 82]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset_key_12", 0, 83]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset_key_12", 0, 84]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 88]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_board_mode} == 0 || ({id_board_mode} == 2 && ({id_switch_type} == 0 || {id_switch_type_key_1} == 0 || {id_switch_type_key_2} == 0 || {id_switch_type_key_3} == 0 || {id_switch_type_key_4} == 0 || {id_switch_type_key_5} == 0 || {id_switch_type_key_6} == 0 || {id_switch_type_key_7} == 0 || {id_switch_type_key_8} == 0 || {id_switch_type_key_9} == 0 || {id_switch_type_key_10} == 0 || {id_switch_type_key_11} == 0 || {id_switch_type_key_12} == 0))",
           "label": "Calibration",
           "content": [
             {
-              "showIf": "{id_switch_type} == 0",
               "content": [
                 {
                   "label": "Board Calibration",
                   "type": "toggle",
-                  "content": ["id_bottoming_calibration", 0, 8]
+                  "content": ["id_bottoming_calibration", 0, 92]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_print_calibration_data", 0, 10]
+                  "content": ["id_show_calibration_data", 0, 94]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
                   "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottom_out_calibration", 0, 11]
+                  "content": ["id_clear_bottoming_calibration_data", 0, 95]
                 }
               ]
             }
@@ -285,7 +1383,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
       "label": "Gaming Features",
       "content": [
         {
@@ -301,7 +1398,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_1_mode", 0, 13]
+              "content": ["id_socd_pair_1_mode", 0, 97]
             },
             {
               "showIf": "{id_socd_pair_1_mode} != 0",
@@ -309,12 +1406,12 @@
                 {
                   "label": "Pair #1 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_1", 0, 14]
+                  "content": ["id_socd_pair_1_key_1", 0, 98]
                 },
                 {
                   "label": "Pair #1 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_2", 0, 15]
+                  "content": ["id_socd_pair_1_key_2", 0, 99]
                 }
               ]
             },
@@ -328,7 +1425,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_2_mode", 0, 16]
+              "content": ["id_socd_pair_2_mode", 0, 100]
             },
             {
               "showIf": "{id_socd_pair_2_mode} != 0",
@@ -336,12 +1433,12 @@
                 {
                   "label": "Pair #2 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 17]
+                  "content": ["id_socd_pair_2_key_1", 0, 101]
                 },
                 {
                   "label": "Pair #2 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 18]
+                  "content": ["id_socd_pair_2_key_2", 0, 102]
                 }
               ]
             },
@@ -355,7 +1452,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_3_mode", 0, 19]
+              "content": ["id_socd_pair_3_mode", 0, 103]
             },
             {
               "showIf": "{id_socd_pair_3_mode} != 0",
@@ -363,12 +1460,12 @@
                 {
                   "label": "Pair #3 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 20]
+                  "content": ["id_socd_pair_3_key_1", 0, 104]
                 },
                 {
                   "label": "Pair #3 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 21]
+                  "content": ["id_socd_pair_3_key_2", 0, 105]
                 }
               ]
             },
@@ -382,7 +1479,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_4_mode", 0, 22]
+              "content": ["id_socd_pair_4_mode", 0, 106]
             },
             {
               "showIf": "{id_socd_pair_4_mode} != 0",
@@ -390,12 +1487,12 @@
                 {
                   "label": "Pair #4 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 23]
+                  "content": ["id_socd_pair_4_key_1", 0, 107]
                 },
                 {
                   "label": "Pair #4 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 24]
+                  "content": ["id_socd_pair_4_key_2", 0, 108]
                 }
               ]
             }
@@ -404,7 +1501,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
       "label": "Tap Dance",
       "content": [
         {
@@ -906,7 +2002,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
       "label": "Combos",
       "content": [
         {
@@ -1272,7 +2367,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
       "label": "QMK Settings",
       "content": [
         {
@@ -1558,37 +2652,32 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "System",
       "content": [
         {
           "label": "Maintenance",
           "content": [
             {
-              "showIf": "{id_firmware_version} >= 3",
               "label": "Firmware Version",
               "type": "label",
-              "content": ["id_firmware_version_text", 0, 27]
+              "content": ["id_firmware_version_text", 0, 112]
             },
             {
-              "showIf": "{id_firmware_version} >= 3",
               "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_date_text", 0, 28]
+              "content": ["id_firmware_build_text", 0, 113]
             },
             {
-              "showIf": "{id_firmware_version} >= 4",
               "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_enter_bootloader", 0, 25]
+              "content": ["id_flash_mode", 0, 110]
             },
             {
-              "showIf": "{id_firmware_version} >= 4",
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 26]
+              "content": ["id_factory_reset", 0, 111]
             }
           ]
         }
@@ -1648,7 +2737,7 @@
           "c": "#aaaaaa",
           "w": 1.75
         },
-        "3,0",
+        "3,14",
         {
           "c": "#cccccc"
         },
@@ -1667,29 +2756,29 @@
         {
           "w": 2.25
         },
-        "4,0",
+        "4,17",
         {
           "x": 12.25,
           "w": 1.75
         },
-        "3,12\n\n\n1,0",
+        "3,15\n\n\n1,0",
         {
           "c": "#cccccc"
         },
-        "3,13\n\n\n1,0",
+        "3,16\n\n\n1,0",
         {
           "x": 0.25,
           "c": "#aaaaaa",
           "w": 2.75
         },
-        "3,12\n\n\n1,1"
+        "3,15\n\n\n1,1"
       ],
       [
         {
           "y": 0.25,
           "x": 1.75
         },
-        "4,1"
+        "4,18"
       ],
       [
         {
@@ -1718,7 +2807,7 @@
           "x": -2.2,
           "c": "#aaaaaa"
         },
-        "4,10"
+        "4,25"
       ],
       [
         {
@@ -1775,7 +2864,7 @@
           "c": "#aaaaaa",
           "w": 1.5
         },
-        "4,2"
+        "4,19"
       ],
       [
         {
@@ -1850,7 +2939,7 @@
           "x": 0.65,
           "w": 3
         },
-        "4,4\n\n\n2,0"
+        "4,20\n\n\n2,0"
       ],
       [
         {
@@ -1858,11 +2947,11 @@
           "x": 0.65,
           "w": 2
         },
-        "4,4\n\n\n2,1",
+        "4,20\n\n\n2,1",
         {
           "c": "#aaaaaa"
         },
-        "4,5\n\n\n2,1"
+        "4,21\n\n\n2,1"
       ],
       [
         {
@@ -1951,7 +3040,7 @@
           "x": -3.85,
           "w": 3
         },
-        "4,7\n\n\n3,0"
+        "4,23\n\n\n3,0"
       ],
       [
         {
@@ -1959,12 +3048,12 @@
           "x": -3.85,
           "c": "#aaaaaa"
         },
-        "4,6\n\n\n3,1",
+        "4,22\n\n\n3,1",
         {
           "c": "#cccccc",
           "w": 2
         },
-        "4,7\n\n\n3,1"
+        "4,23\n\n\n3,1"
       ],
       [
         {
@@ -2046,7 +3135,7 @@
           "c": "#aaaaaa",
           "w": 1.5
         },
-        "4,9"
+        "4,24"
       ],
       [
         {

--- a/v3/cipulot/hybrid_hhkb/hybrid_hhkb.json
+++ b/v3/cipulot/hybrid_hhkb/hybrid_hhkb.json
@@ -1,10 +1,10 @@
 {
-  "name": "EC Alice",
+  "name": "Hybrid HHKB",
   "vendorId": "0x6369",
-  "productId": "0x6BF9",
+  "productId": "0x6BFC",
   "matrix": {
     "rows": 5,
-    "cols": 15
+    "cols": 23
   },
   "customKeycodes": [
     {
@@ -160,224 +160,7 @@
   ],
   "keycodes": ["qmk_lighting"],
   "menus": [
-    {
-      "label": "Lighting",
-      "content": [
-        {
-          "label": "Underglow",
-          "content": [
-            {
-              "label": "Brightness",
-              "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_brightness", 2, 1]
-            },
-            {
-              "label": "Effect",
-              "type": "dropdown",
-              "content": ["id_qmk_rgblight_effect", 2, 2],
-              "options": [
-                ["Solid Color", 1],
-                ["Breathing 1", 2],
-                ["Breathing 2", 3],
-                ["Breathing 3", 4],
-                ["Breathing 4", 5],
-                ["Rainbow Mood 1", 6],
-                ["Rainbow Mood 2", 7],
-                ["Rainbow Mood 3", 8],
-                ["Rainbow Swirl 1", 9],
-                ["Rainbow Swirl 2", 10],
-                ["Rainbow Swirl 3", 11],
-                ["Rainbow Swirl 4", 12],
-                ["Rainbow Swirl 5", 13],
-                ["Rainbow Swirl 6", 14],
-                ["Snake 1", 15],
-                ["Snake 2", 16],
-                ["Snake 3", 17],
-                ["Snake 4", 18],
-                ["Snake 5", 19],
-                ["Snake 6", 20],
-                ["Knight 1", 21],
-                ["Knight 2", 22],
-                ["Knight 3", 23],
-                ["Christmas", 24],
-                ["Gradient 1", 25],
-                ["Gradient 2", 26],
-                ["Gradient 3", 27],
-                ["Gradient 4", 28],
-                ["Gradient 5", 29],
-                ["Gradient 6", 30],
-                ["Gradient 7", 31],
-                ["Gradient 8", 32],
-                ["Gradient 9", 33],
-                ["Gradient 10", 34],
-                ["RGB Test", 35],
-                ["Alternating", 36],
-                ["Twinkle 1", 37],
-                ["Twinkle 2", 38],
-                ["Twinkle 3", 39],
-                ["Twinkle 4", 40],
-                ["Twinkle 5", 41],
-                ["Twinkle 6", 42]
-              ]
-            },
-            {
-              "showIf": "{id_qmk_rgblight_effect} != 0",
-              "label": "Effect Speed",
-              "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgblight_effect_speed", 2, 3]
-            },
-            {
-              "showIf": "{id_qmk_rgblight_effect} != 0 && {id_qmk_rgblight_effect} != 35",
-              "label": "Color",
-              "type": "color",
-              "content": ["id_qmk_rgblight_color", 2, 4]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Indicators",
-      "content": [
-        {
-          "label": "Left indicator",
-          "content": [
-            {
-              "label": "Enable Left Indicator",
-              "type": "toggle",
-              "content": ["id_ind3_enabled", 0, 9]
-            },
-            {
-              "showIf": "{id_ind3_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind3_brightness", 0, 10]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind3_color", 0, 11]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind3_func", 0, 12]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Central indicator",
-          "content": [
-            {
-              "label": "Enable Central Indicator",
-              "type": "toggle",
-              "content": ["id_ind2_enabled", 0, 5]
-            },
-            {
-              "showIf": "{id_ind2_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind2_brightness", 0, 6]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind2_color", 0, 7]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind2_func", 0, 8]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Right indicator",
-          "content": [
-            {
-              "label": "Enable Right Indicator",
-              "type": "toggle",
-              "content": ["id_ind1_enabled", 0, 1]
-            },
-            {
-              "showIf": "{id_ind1_enabled} == 1",
-              "content": [
-                {
-                  "label": "Brightness",
-                  "type": "range",
-                  "options": [0, 255],
-                  "content": ["id_ind1_brightness", 0, 2]
-                },
-                {
-                  "label": "Color",
-                  "type": "color",
-                  "content": ["id_ind1_color", 0, 3]
-                },
-                {
-                  "label": "Function",
-                  "type": "dropdown",
-                  "options": [
-                    "None",
-                    "Caps Lock",
-                    "Num Lock",
-                    "Scroll Lock",
-                    "Layer 0",
-                    "Layer 1",
-                    "Layer 2",
-                    "Layer 3",
-                    "Layer 4",
-                    "Layer 5",
-                    "Layer 6",
-                    "Layer 7"
-                  ],
-                  "content": ["id_ind1_func", 0, 4]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
+    "qmk_rgblight",
     {
       "label": "Switch Configuration",
       "content": [
@@ -385,13 +168,24 @@
           "label": "Actuation",
           "content": [
             {
-              "label": "Mode",
+              "label": "Switch Type",
               "type": "dropdown",
-              "options": ["APC", "Rapid Trigger"],
-              "content": ["id_actuation_mode", 0, 13]
+              "options": ["EC", "MX"],
+              "content": ["id_switch_type", 0, 12]
             },
             {
-              "showIf": "{id_actuation_mode} == 0",
+              "showIf": "{id_switch_type} == 0",
+              "content": [
+                {
+                  "label": "Mode",
+                  "type": "dropdown",
+                  "options": ["APC", "Rapid Trigger"],
+                  "content": ["id_actuation_mode", 0, 1]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
                   "label": "Actuation threshold (1-1023)",
@@ -405,7 +199,7 @@
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_actuation_threshold", 0, 14]
+                  "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
                   "label": "Release threshold (1-1023)",
@@ -419,42 +213,42 @@
                       "onViolation": "push"
                     }
                   ],
-                  "content": ["id_apc_release_threshold", 0, 15]
+                  "content": ["id_apc_release_threshold", 0, 3]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 16]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
             {
-              "showIf": "{id_actuation_mode} == 1",
+              "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
                   "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
-                  "content": ["id_rt_initial_deadzone_offset", 0, 17]
+                  "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
                   "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_actuation_offset", 0, 18]
+                  "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
                   "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
-                  "content": ["id_rt_release_offset", 0, 19]
+                  "content": ["id_rt_release_offset", 0, 7]
                 },
                 {
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 16]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -464,23 +258,28 @@
           "label": "Calibration",
           "content": [
             {
-              "label": "Board Calibration",
-              "type": "toggle",
-              "content": ["id_bottoming_calibration", 0, 20]
-            },
-            {
-              "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Print calibration data to console",
-              "type": "button",
-              "options": [0],
-              "content": ["id_show_calibration_data", 0, 22]
-            },
-            {
-              "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear bottom-out calibration data",
-              "type": "button",
-              "options": [0],
-              "content": ["id_clear_bottoming_calibration_data", 0, 23]
+              "showIf": "{id_switch_type} == 0",
+              "content": [
+                {
+                  "label": "Board Calibration",
+                  "type": "toggle",
+                  "content": ["id_bottoming_calibration", 0, 8]
+                },
+                {
+                  "showIf": "{id_bottoming_calibration} == 0",
+                  "label": "Print calibration data to console",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_print_calibration_data", 0, 10]
+                },
+                {
+                  "showIf": "{id_bottoming_calibration} == 0",
+                  "label": "Clear bottom-out calibration data",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
+                }
+              ]
             }
           ]
         }
@@ -502,7 +301,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_1_mode", 0, 24]
+              "content": ["id_socd_pair_1_mode", 0, 13]
             },
             {
               "showIf": "{id_socd_pair_1_mode} != 0",
@@ -510,12 +309,12 @@
                 {
                   "label": "Pair #1 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_1", 0, 25]
+                  "content": ["id_socd_pair_1_key_1", 0, 14]
                 },
                 {
                   "label": "Pair #1 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_2", 0, 26]
+                  "content": ["id_socd_pair_1_key_2", 0, 15]
                 }
               ]
             },
@@ -529,7 +328,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_2_mode", 0, 27]
+              "content": ["id_socd_pair_2_mode", 0, 16]
             },
             {
               "showIf": "{id_socd_pair_2_mode} != 0",
@@ -537,12 +336,12 @@
                 {
                   "label": "Pair #2 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 28]
+                  "content": ["id_socd_pair_2_key_1", 0, 17]
                 },
                 {
                   "label": "Pair #2 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 29]
+                  "content": ["id_socd_pair_2_key_2", 0, 18]
                 }
               ]
             },
@@ -556,7 +355,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_3_mode", 0, 30]
+              "content": ["id_socd_pair_3_mode", 0, 19]
             },
             {
               "showIf": "{id_socd_pair_3_mode} != 0",
@@ -564,12 +363,12 @@
                 {
                   "label": "Pair #3 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 31]
+                  "content": ["id_socd_pair_3_key_1", 0, 20]
                 },
                 {
                   "label": "Pair #3 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 32]
+                  "content": ["id_socd_pair_3_key_2", 0, 21]
                 }
               ]
             },
@@ -583,7 +382,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_4_mode", 0, 33]
+              "content": ["id_socd_pair_4_mode", 0, 22]
             },
             {
               "showIf": "{id_socd_pair_4_mode} != 0",
@@ -591,12 +390,12 @@
                 {
                   "label": "Pair #4 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 34]
+                  "content": ["id_socd_pair_4_key_1", 0, 23]
                 },
                 {
                   "label": "Pair #4 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 35]
+                  "content": ["id_socd_pair_4_key_2", 0, 24]
                 }
               ]
             }
@@ -605,7 +404,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "Tap Dance",
       "content": [
         {
@@ -1107,7 +905,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "Combos",
       "content": [
         {
@@ -1473,7 +1270,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
       "label": "QMK Settings",
       "content": [
         {
@@ -1759,35 +1555,32 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
       "label": "System",
       "content": [
         {
           "label": "Maintenance",
           "content": [
             {
-              "showIf": "{id_firmware_version} >= 2",
               "label": "Firmware Version",
               "type": "label",
-              "content": ["id_firmware_version_text", 0, 38]
+              "content": ["id_firmware_version_text", 0, 27]
             },
             {
-              "showIf": "{id_firmware_version} >= 2",
               "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 39]
+              "content": ["id_firmware_build_date_text", 0, 28]
             },
             {
               "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 36]
+              "content": ["id_enter_bootloader", 0, 25]
             },
             {
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 37]
+              "content": ["id_factory_reset", 0, 26]
             }
           ]
         }
@@ -1795,287 +1588,128 @@
     }
   ],
   "layouts": {
-    "labels": [
-      "Split Backspace",
-      ["Right Shift", "HHKB", "Unified"],
-      ["Left Spacebar", "2U", "2.25U"]
-    ],
     "keymap": [
       [
-        {
-          "y": 0.9,
-          "x": 0.55,
-          "c": "#777777"
-        },
-        "0,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 3.7,
-          "c": "#cccccc"
-        },
-        "0,2",
-        {
-          "x": 8.45
-        },
-        "0,11"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 1.7
-        },
-        "1,0",
+        "0,15",
+        "0,0",
         "0,1",
-        {
-          "x": 10.45
-        },
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
         "0,12",
         {
-          "c": "#aaaaaa",
-          "w": 2
+          "c": "#aaaaaa"
         },
-        "0,14\n\n\n0,0",
-        {
-          "x": 1.35
-        },
-        "0,13\n\n\n0,1",
-        "0,14\n\n\n0,1"
+        "1,12"
       ],
       [
         {
-          "y": -0.1,
-          "x": 0.35
-        },
-        "2,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 13,
-          "c": "#cccccc"
-        },
-        "1,11"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 1.5,
-          "c": "#aaaaaa",
           "w": 1.5
         },
+        "1,15",
+        {
+          "c": "#cccccc"
+        },
+        "1,0",
         "1,1",
-        {
-          "c": "#cccccc"
-        },
         "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
         {
-          "x": 10
-        },
-        "1,12",
-        "1,13",
-        {
-          "c": "#aaaaaa",
           "w": 1.5
         },
-        "1,14"
+        "2,12"
       ],
       [
         {
-          "y": -0.1,
-          "x": 0.15
-        },
-        "3,0"
-      ],
-      [
-        {
-          "y": -0.9,
-          "x": 1.3,
+          "c": "#aaaaaa",
           "w": 1.75
         },
-        "2,1",
+        "2,16",
         {
           "c": "#cccccc"
         },
+        "2,0",
+        "2,1",
         "2,2",
-        {
-          "x": 9.35
-        },
-        "2,11",
-        "2,12",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
         {
           "c": "#777777",
           "w": 2.25
         },
-        "2,14"
+        "3,12"
       ],
       [
         {
-          "x": 1.05,
           "c": "#aaaaaa",
           "w": 2.25
         },
-        "3,1",
+        "3,17",
         {
           "c": "#cccccc"
         },
+        "3,1",
         "3,2",
-        {
-          "x": 8.8
-        },
-        "3,11",
-        "3,12",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
         {
           "c": "#aaaaaa",
           "w": 1.75
         },
-        "3,13\n\n\n1,0",
-        "3,14\n\n\n1,0",
+        "3,13",
         {
-          "x": 0.5,
-          "w": 2.75
-        },
-        "3,13\n\n\n1,1"
-      ],
-      [
-        {
-          "x": 1.05,
-          "w": 1.5
-        },
-        "4,1",
-        {
-          "x": 13.55,
-          "w": 1.5
-        },
-        "4,14"
-      ],
-      [
-        {
-          "r": 12,
-          "y": -6,
-          "x": 5.05,
           "c": "#cccccc"
         },
-        "0,3",
-        "0,4",
-        "0,5",
-        "0,6"
+        "3,14"
       ],
       [
         {
-          "x": 4.6
-        },
-        "1,3",
-        "1,4",
-        "1,5",
-        "1,6"
-      ],
-      [
-        {
-          "x": 4.85
-        },
-        "2,3",
-        "2,4",
-        "2,5",
-        "2,6"
-      ],
-      [
-        {
-          "x": 5.3
-        },
-        "3,3",
-        "3,4",
-        "3,5",
-        "3,6"
-      ],
-      [
-        {
-          "x": 6.6,
-          "w": 2
-        },
-        "4,5\n\n\n2,0",
-        {
-          "c": "#aaaaaa",
-          "w": 1.25
-        },
-        "4,6\n\n\n2,0"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 5.05,
-          "w": 1.5
-        },
-        "4,3"
-      ],
-      [
-        {
-          "y": 0.35,
-          "x": 6.6,
-          "c": "#cccccc",
-          "w": 2.25
-        },
-        "4,5\n\n\n2,1",
-        {
+          "x": 1.5,
           "c": "#aaaaaa"
         },
-        "4,6\n\n\n2,1"
-      ],
-      [
+        "4,18",
         {
-          "r": -12,
-          "y": -2.8,
-          "x": 8.45,
-          "c": "#cccccc"
+          "w": 1.5
         },
-        "0,7",
-        "0,8",
-        "0,9",
-        "0,10"
-      ],
-      [
+        "4,19",
         {
-          "x": 8.05
+          "c": "#cccccc",
+          "w": 6
         },
-        "1,7",
-        "1,8",
-        "1,9",
-        "1,10"
-      ],
-      [
+        "4,20",
         {
-          "x": 8.2
-        },
-        "2,7",
-        "2,8",
-        "2,9",
-        "2,10"
-      ],
-      [
-        {
-          "x": 7.75
-        },
-        "3,7",
-        "3,8",
-        "3,9",
-        "3,10"
-      ],
-      [
-        {
-          "x": 7.75,
-          "w": 2.75
-        },
-        "4,8"
-      ],
-      [
-        {
-          "y": -0.95,
-          "x": 10.55,
           "c": "#aaaaaa",
           "w": 1.5
         },
-        "4,10"
+        "4,21",
+        "4,22"
       ]
     ]
   }

--- a/v3/cipulot/hybrid_is0gr/hybrid_is0gr.json
+++ b/v3/cipulot/hybrid_is0gr/hybrid_is0gr.json
@@ -6,9 +6,162 @@
     "rows": 1,
     "cols": 1
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
+  "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Hybrid Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -34,7 +187,7 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -48,7 +201,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -65,7 +218,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
@@ -73,19 +226,19 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -94,7 +247,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -113,17 +266,17 @@
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Show Board Calibration Data",
+                  "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_show_calibration_data", 0, 10]
+                  "content": ["id_print_calibration_data", 0, 10]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Clear Board Calibration Data",
+                  "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottoming_calibration_data", 0, 11]
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
                 }
               ]
             }
@@ -132,6 +285,1280 @@
       ]
     },
     {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Gaming Features",
+      "content": [
+        {
+          "label": "SOCD",
+          "content": [
+            {
+              "label": "Pair #1 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_1_mode", 0, 13]
+            },
+            {
+              "showIf": "{id_socd_pair_1_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 14]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 15]
+                }
+              ]
+            },
+            {
+              "label": "Pair #2 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_2_mode", 0, 16]
+            },
+            {
+              "showIf": "{id_socd_pair_2_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 17]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 18]
+                }
+              ]
+            },
+            {
+              "label": "Pair #3 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_3_mode", 0, 19]
+            },
+            {
+              "showIf": "{id_socd_pair_3_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 20]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 21]
+                }
+              ]
+            },
+            {
+              "label": "Pair #4 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_4_mode", 0, 22]
+            },
+            {
+              "showIf": "{id_socd_pair_4_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 23]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 24]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
+      "content": [
+        {
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} < 4",
       "label": "Board System",
       "content": [
         {
@@ -160,6 +1587,41 @@
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 14]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
+          "content": [
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Firmware Version",
+              "type": "label",
+              "content": ["id_firmware_version_text", 0, 27]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Firmware build date",
+              "type": "label",
+              "content": ["id_firmware_build_date_text", 0, 28]
+            },
+            {
+              "label": "Enter bootloader",
+              "type": "button",
+              "options": [0],
+              "content": ["id_enter_bootloader", 0, 25]
+            },
+            {
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 26]
             }
           ]
         }

--- a/v3/cipulot/hybrid_kenban_de_go/hybrid_kenban_de_go.json
+++ b/v3/cipulot/hybrid_kenban_de_go/hybrid_kenban_de_go.json
@@ -6,9 +6,162 @@
     "rows": 8,
     "cols": 7
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
+  "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Hybrid Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -34,7 +187,7 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -48,7 +201,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -65,7 +218,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
@@ -73,19 +226,19 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -94,7 +247,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -113,17 +266,17 @@
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Show Board Calibration Data",
+                  "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_show_calibration_data", 0, 10]
+                  "content": ["id_print_calibration_data", 0, 10]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Clear Board Calibration Data",
+                  "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottoming_calibration_data", 0, 11]
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
                 }
               ]
             }
@@ -133,7 +286,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -251,11 +404,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -265,21 +1572,21 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 28]
+              "content": ["id_firmware_build_date_text", 0, 28]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 24]
+              "content": ["id_enter_bootloader", 0, 25]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 25]
+              "content": ["id_factory_reset", 0, 26]
             }
           ]
         }

--- a/v3/cipulot/hybrid_little_man_40/hybrid_little_man_40.json
+++ b/v3/cipulot/hybrid_little_man_40/hybrid_little_man_40.json
@@ -6,9 +6,162 @@
     "rows": 11,
     "cols": 4
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
+  "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Hybrid Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -34,7 +187,7 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -48,7 +201,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -65,7 +218,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             },
@@ -73,19 +226,19 @@
               "showIf": "{id_switch_type} == 0 && {id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -94,7 +247,7 @@
                   "label": "Apply & save changes",
                   "type": "button",
                   "options": [1],
-                  "content": ["id_save_threshold_data", 0, 4]
+                  "content": ["id_apply_thresholds", 0, 4]
                 }
               ]
             }
@@ -113,17 +266,17 @@
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Show Board Calibration Data",
+                  "label": "Print calibration data to console",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_show_calibration_data", 0, 10]
+                  "content": ["id_print_calibration_data", 0, 10]
                 },
                 {
                   "showIf": "{id_bottoming_calibration} == 0",
-                  "label": "Clear Board Calibration Data",
+                  "label": "Clear bottom-out calibration data",
                   "type": "button",
                   "options": [0],
-                  "content": ["id_clear_bottoming_calibration_data", 0, 11]
+                  "content": ["id_clear_bottom_out_calibration", 0, 11]
                 }
               ]
             }
@@ -133,7 +286,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -251,10 +404,1165 @@
       ]
     },
     {
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Information",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 2",
@@ -264,9 +1572,23 @@
             },
             {
               "showIf": "{id_firmware_version} >= 2",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 28]
+              "content": ["id_firmware_build_date_text", 0, 28]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "label": "Enter bootloader",
+              "type": "button",
+              "options": [0],
+              "content": ["id_enter_bootloader", 0, 25]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 26]
             }
           ]
         }

--- a/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
+++ b/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
@@ -8,7 +8,7 @@
   },
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +23,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +37,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +62,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +99,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -116,10 +116,1282 @@
       ]
     },
     {
-      "label": "Board System",
+      "label": "Gaming Features",
       "content": [
         {
-          "label": "Board Information",
+          "label": "SOCD",
+          "content": [
+            {
+              "label": "Pair #1 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_1_mode", 0, 14]
+            },
+            {
+              "showIf": "{id_socd_pair_1_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 15]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 16]
+                }
+              ]
+            },
+            {
+              "label": "Pair #2 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_2_mode", 0, 17]
+            },
+            {
+              "showIf": "{id_socd_pair_2_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 18]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 19]
+                }
+              ]
+            },
+            {
+              "label": "Pair #3 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_3_mode", 0, 20]
+            },
+            {
+              "showIf": "{id_socd_pair_3_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 21]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 22]
+                }
+              ]
+            },
+            {
+              "label": "Pair #4 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_4_mode", 0, 23]
+            },
+            {
+              "showIf": "{id_socd_pair_4_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 24]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 25]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Tap Dance",
+      "content": [
+        {
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 2",
@@ -129,9 +1401,21 @@
             },
             {
               "showIf": "{id_firmware_version} >= 2",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 13]
+            },
+            {
+              "label": "Enter bootloader",
+              "type": "button",
+              "options": [0],
+              "content": ["id_flash_mode", 0, 26]
+            },
+            {
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 27]
             }
           ]
         }

--- a/v3/cipulot/leila/ec_leila.json
+++ b/v3/cipulot/leila/ec_leila.json
@@ -6,6 +6,158 @@
     "rows": 6,
     "cols": 22
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
       "label": "Indicators",
@@ -148,7 +300,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -163,7 +315,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -177,7 +329,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 14]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -202,19 +354,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 17]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 18]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 19]
@@ -235,18 +387,18 @@
             {
               "label": "Board Calibration",
               "type": "toggle",
-              "content": ["id_bottoming_calibration", 0, 8]
+              "content": ["id_bottoming_calibration", 0, 20]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
-              "content": ["id_show_calibration_data", 0, 10]
+              "content": ["id_show_calibration_data", 0, 22]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 23]
@@ -256,8 +408,7 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -375,32 +526,1180 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
           "content": [
             {
-              "showIf": "{id_firmware_version} >= 3",
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
+          "content": [
+            {
               "label": "Firmware Version",
               "type": "label",
               "content": ["id_firmware_version_text", 0, 38]
             },
             {
-              "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 39]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 36]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 37]

--- a/v3/cipulot/leila/mx_leila.json
+++ b/v3/cipulot/leila/mx_leila.json
@@ -148,7 +148,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
       "label": "Advanced Features",
       "content": [
         {
@@ -267,7 +266,6 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
       "label": "Board System",
       "content": [
         {
@@ -277,7 +275,7 @@
               "label": "Flash Mode",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 24]
+              "content": ["id_flash_mode", 0, 25]
             },
             {
               "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",

--- a/v3/cipulot/logos_mk1_wrk/logos_mk1_wrk_ec.json
+++ b/v3/cipulot/logos_mk1_wrk/logos_mk1_wrk_ec.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 18
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/mkn_60_ec/mnk_60_ec.json
+++ b/v3/cipulot/mkn_60_ec/mnk_60_ec.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 14
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,20 +387,1186 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
           "content": [
             {
-              "label": "Flash Mode",
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
+          "content": [
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Firmware Version",
+              "type": "label",
+              "content": ["id_firmware_version_text", 0, 26]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 4",
+              "label": "Firmware build date",
+              "type": "label",
+              "content": ["id_firmware_build_text", 0, 27]
+            },
+            {
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/mnk_65_ec/mnk_65_ec.json
+++ b/v3/cipulot/mnk_65_ec/mnk_65_ec.json
@@ -6,9 +6,161 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -23,7 +175,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -37,7 +189,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -62,19 +214,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -99,14 +251,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -117,7 +269,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 1",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -235,11 +387,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 2",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 3",
@@ -249,18 +1555,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 3",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]

--- a/v3/cipulot/rf_r1_8_9xu/rf_r1_8_9xu.json
+++ b/v3/cipulot/rf_r1_8_9xu/rf_r1_8_9xu.json
@@ -6,11 +6,163 @@
     "rows": 6,
     "cols": 16
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "keycodes": ["qmk_lighting"],
   "menus": [
     "qmk_rgblight",
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -25,7 +177,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -39,7 +191,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 2]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -64,19 +216,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 5]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 6]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 7]
@@ -101,14 +253,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 10]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
@@ -119,7 +271,7 @@
     },
     {
       "showIf": "{id_firmware_version} >= 2",
-      "label": "Advanced Features",
+      "label": "Gaming Features",
       "content": [
         {
           "label": "SOCD",
@@ -237,11 +389,1165 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 3",
-      "label": "Board System",
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Tap Dance",
       "content": [
         {
-          "label": "Board Maintenance",
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 3",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
           "content": [
             {
               "showIf": "{id_firmware_version} >= 4",
@@ -251,18 +1557,18 @@
             },
             {
               "showIf": "{id_firmware_version} >= 4",
-              "label": "Firmware Build",
+              "label": "Firmware build date",
               "type": "label",
               "content": ["id_firmware_build_text", 0, 27]
             },
             {
-              "label": "Flash Mode",
+              "label": "Enter bootloader",
               "type": "button",
               "options": [0],
               "content": ["id_flash_mode", 0, 24]
             },
             {
-              "label": "FACTORY RESET (Unplug the board and plug it back in to complete the procedure)",
+              "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
               "content": ["id_factory_reset", 0, 25]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
