### PR TITLE
More json for testing before push

### DIFF
--- a/v3/cipulot/ec_660c/ec_660c.json
+++ b/v3/cipulot/ec_660c/ec_660c.json
@@ -6,6 +6,158 @@
     "rows": 5,
     "cols": 15
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
       "showIf": "{id_firmware_version} >= 3",

--- a/v3/cipulot/ec_980c/legacy_ec_980c.json
+++ b/v3/cipulot/ec_980c/legacy_ec_980c.json
@@ -9,7 +9,7 @@
   "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Lightning",
+      "label": "Lighting",
       "content": [
         {
           "label": "Indicators",
@@ -102,7 +102,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -117,7 +117,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -131,7 +131,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 11]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -156,19 +156,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 14]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 15]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 16]
@@ -193,14 +193,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 19]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 20]

--- a/v3/cipulot/ec_alice/legacy_ec_alice.json
+++ b/v3/cipulot/ec_alice/legacy_ec_alice.json
@@ -207,7 +207,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -222,7 +222,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -236,7 +236,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 17]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -261,19 +261,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 20]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 21]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 22]
@@ -298,14 +298,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 25]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 26]

--- a/v3/cipulot/ec_typek/legacy_ec_typek_advanced.json
+++ b/v3/cipulot/ec_typek/legacy_ec_typek_advanced.json
@@ -207,7 +207,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -222,7 +222,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -236,7 +236,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 17]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -261,19 +261,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 20]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 21]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 22]
@@ -298,14 +298,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 25]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 26]

--- a/v3/cipulot/ec_typek/legacy_ec_typek_basic.json
+++ b/v3/cipulot/ec_typek/legacy_ec_typek_basic.json
@@ -9,7 +9,7 @@
   "keycodes": ["qmk_lighting"],
   "menus": [
     {
-      "label": "Lightning",
+      "label": "Lighting",
       "content": [
         {
           "label": "Indicators",
@@ -147,7 +147,7 @@
       ]
     },
     {
-      "label": "EC Tools",
+      "label": "Switch Configuration",
       "content": [
         {
           "label": "Actuation",
@@ -162,7 +162,7 @@
               "showIf": "{id_actuation_mode} == 0",
               "content": [
                 {
-                  "label": "Actuation Level (0% | 100%)",
+                  "label": "Actuation threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -176,7 +176,7 @@
                   "content": ["id_apc_actuation_threshold", 0, 11]
                 },
                 {
-                  "label": "Release Level (0% | 100%)",
+                  "label": "Release threshold (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "constraints": [
@@ -201,19 +201,19 @@
               "showIf": "{id_actuation_mode} == 1",
               "content": [
                 {
-                  "label": "Initial Deadzone Offset (0% | 100%)",
+                  "label": "Initial deadzone offset (1-1023)",
                   "type": "range",
                   "options": [1, 1023],
                   "content": ["id_rt_initial_deadzone_offset", 0, 14]
                 },
                 {
-                  "label": "Actuation Offset (1-255)",
+                  "label": "Actuation offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_actuation_offset", 0, 15]
                 },
                 {
-                  "label": "Release Offset (1-255)",
+                  "label": "Release offset (1-255)",
                   "type": "range",
                   "options": [1, 255],
                   "content": ["id_rt_release_offset", 0, 16]
@@ -238,14 +238,14 @@
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Show Board Calibration Data",
+              "label": "Print calibration data to console",
               "type": "button",
               "options": [0],
               "content": ["id_show_calibration_data", 0, 19]
             },
             {
               "showIf": "{id_bottoming_calibration} == 0",
-              "label": "Clear Board Calibration Data",
+              "label": "Clear bottom-out calibration data",
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 20]

--- a/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
+++ b/v3/cipulot/je_bae_ted/ec_je_bae_ted.json
@@ -6,6 +6,158 @@
     "rows": 2,
     "cols": 1
   },
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "menus": [
     {
       "label": "Switch Configuration",
@@ -110,124 +262,6 @@
               "type": "button",
               "options": [0],
               "content": ["id_clear_bottoming_calibration_data", 0, 11]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Gaming Features",
-      "content": [
-        {
-          "label": "SOCD",
-          "content": [
-            {
-              "label": "Pair #1 Mode",
-              "type": "dropdown",
-              "options": [
-                ["Disabled", 0],
-                ["Last Priority", 1],
-                ["Neutral", 2],
-                ["First Key Priority", 3],
-                ["Second Key Priority", 4]
-              ],
-              "content": ["id_socd_pair_1_mode", 0, 14]
-            },
-            {
-              "showIf": "{id_socd_pair_1_mode} != 0",
-              "content": [
-                {
-                  "label": "Pair #1 First Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_1_key_1", 0, 15]
-                },
-                {
-                  "label": "Pair #1 Second Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_1_key_2", 0, 16]
-                }
-              ]
-            },
-            {
-              "label": "Pair #2 Mode",
-              "type": "dropdown",
-              "options": [
-                ["Disabled", 0],
-                ["Last Priority", 1],
-                ["Neutral", 2],
-                ["First Key Priority", 3],
-                ["Second Key Priority", 4]
-              ],
-              "content": ["id_socd_pair_2_mode", 0, 17]
-            },
-            {
-              "showIf": "{id_socd_pair_2_mode} != 0",
-              "content": [
-                {
-                  "label": "Pair #2 First Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 18]
-                },
-                {
-                  "label": "Pair #2 Second Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 19]
-                }
-              ]
-            },
-            {
-              "label": "Pair #3 Mode",
-              "type": "dropdown",
-              "options": [
-                ["Disabled", 0],
-                ["Last Priority", 1],
-                ["Neutral", 2],
-                ["First Key Priority", 3],
-                ["Second Key Priority", 4]
-              ],
-              "content": ["id_socd_pair_3_mode", 0, 20]
-            },
-            {
-              "showIf": "{id_socd_pair_3_mode} != 0",
-              "content": [
-                {
-                  "label": "Pair #3 First Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 21]
-                },
-                {
-                  "label": "Pair #3 Second Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 22]
-                }
-              ]
-            },
-            {
-              "label": "Pair #4 Mode",
-              "type": "dropdown",
-              "options": [
-                ["Disabled", 0],
-                ["Last Priority", 1],
-                ["Neutral", 2],
-                ["First Key Priority", 3],
-                ["Second Key Priority", 4]
-              ],
-              "content": ["id_socd_pair_4_mode", 0, 23]
-            },
-            {
-              "showIf": "{id_socd_pair_4_mode} != 0",
-              "content": [
-                {
-                  "label": "Pair #4 First Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 24]
-                },
-                {
-                  "label": "Pair #4 Second Key",
-                  "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 25]
-                }
-              ]
             }
           ]
         }
@@ -1409,13 +1443,13 @@
               "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 26]
+              "content": ["id_flash_mode", 0, 14]
             },
             {
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 27]
+              "content": ["id_factory_reset", 0, 15]
             }
           ]
         }

--- a/v3/cipulot/raita_ec/raita_ec.json
+++ b/v3/cipulot/raita_ec/raita_ec.json
@@ -1,12 +1,11 @@
 {
-  "name": "EC 60X JOKER",
+  "name": "Raita EC",
   "vendorId": "0x6369",
-  "productId": "0x6BF6",
+  "productId": "0x6B83",
   "matrix": {
-    "rows": 5,
-    "cols": 15
+    "rows": 8,
+    "cols": 1
   },
-  "keycodes": ["qmk_lighting"],
   "customKeycodes": [
     {
       "name": "TD(0)",
@@ -160,7 +159,6 @@
     }
   ],
   "menus": [
-    "qmk_rgblight",
     {
       "label": "Switch Configuration",
       "content": [
@@ -269,7 +267,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_1_mode", 0, 12]
+              "content": ["id_socd_pair_1_mode", 0, 15]
             },
             {
               "showIf": "{id_socd_pair_1_mode} != 0",
@@ -296,7 +294,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_2_mode", 0, 15]
+              "content": ["id_socd_pair_2_mode", 0, 19]
             },
             {
               "showIf": "{id_socd_pair_2_mode} != 0",
@@ -304,12 +302,12 @@
                 {
                   "label": "Pair #2 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 16]
+                  "content": ["id_socd_pair_2_key_1", 0, 17]
                 },
                 {
                   "label": "Pair #2 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 17]
+                  "content": ["id_socd_pair_2_key_2", 0, 18]
                 }
               ]
             },
@@ -323,7 +321,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_3_mode", 0, 18]
+              "content": ["id_socd_pair_3_mode", 0, 23]
             },
             {
               "showIf": "{id_socd_pair_3_mode} != 0",
@@ -331,12 +329,12 @@
                 {
                   "label": "Pair #3 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 19]
+                  "content": ["id_socd_pair_3_key_1", 0, 21]
                 },
                 {
                   "label": "Pair #3 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 20]
+                  "content": ["id_socd_pair_3_key_2", 0, 22]
                 }
               ]
             },
@@ -350,7 +348,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_4_mode", 0, 21]
+              "content": ["id_socd_pair_4_mode", 0, 27]
             },
             {
               "showIf": "{id_socd_pair_4_mode} != 0",
@@ -358,12 +356,12 @@
                 {
                   "label": "Pair #4 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 22]
+                  "content": ["id_socd_pair_4_key_1", 0, 25]
                 },
                 {
                   "label": "Pair #4 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 23]
+                  "content": ["id_socd_pair_4_key_2", 0, 26]
                 }
               ]
             }
@@ -372,7 +370,7 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
+      "showIf": "{id_firmware_version} >= 3",
       "label": "Tap Dance",
       "content": [
         {
@@ -874,7 +872,7 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
+      "showIf": "{id_firmware_version} >= 3",
       "label": "Combos",
       "content": [
         {
@@ -1240,7 +1238,7 @@
       ]
     },
     {
-      "showIf": "{id_firmware_version} >= 4",
+      "showIf": "{id_firmware_version} >= 3",
       "label": "QMK Settings",
       "content": [
         {
@@ -1536,25 +1534,25 @@
               "showIf": "{id_firmware_version} >= 3",
               "label": "Firmware Version",
               "type": "label",
-              "content": ["id_firmware_version_text", 0, 26]
+              "content": ["id_firmware_version_text", 0, 28]
             },
             {
               "showIf": "{id_firmware_version} >= 3",
               "label": "Firmware build date",
               "type": "label",
-              "content": ["id_firmware_build_text", 0, 27]
+              "content": ["id_firmware_build_text", 0, 29]
             },
             {
               "label": "Enter bootloader",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 24]
+              "content": ["id_flash_mode", 0, 30]
             },
             {
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 25]
+              "content": ["id_factory_reset", 0, 31]
             }
           ]
         }
@@ -1562,190 +1560,9 @@
     }
   ],
   "layouts": {
-    "labels": [
-      "Split Backspace",
-      "Split Left Shift",
-      ["Right Shift", "Unified", "1.75U | 1U", "1U | 1.75U"],
-      "ISO"
-    ],
     "keymap": [
-      [
-        {
-          "x": 2.5
-        },
-        "0,0",
-        "0,1",
-        "0,2",
-        "0,3",
-        "0,4",
-        "0,5",
-        "0,6",
-        "0,7",
-        "0,8",
-        "0,9",
-        "0,10",
-        "0,11",
-        "0,12",
-        {
-          "c": "#aaaaaa",
-          "w": 2
-        },
-        "0,14\n\n\n0,0",
-        {
-          "x": 1,
-          "c": "#cccccc"
-        },
-        "0,13\n\n\n0,1",
-        {
-          "c": "#aaaaaa"
-        },
-        "0,14\n\n\n0,1"
-      ],
-      [
-        {
-          "x": 2.5,
-          "w": 1.5
-        },
-        "1,0",
-        {
-          "c": "#cccccc"
-        },
-        "1,1",
-        "1,2",
-        "1,3",
-        "1,4",
-        "1,5",
-        "1,6",
-        "1,7",
-        "1,8",
-        "1,9",
-        "1,10",
-        "1,11",
-        "1,12",
-        {
-          "w": 1.5
-        },
-        "1,13\n\n\n3,0",
-        {
-          "x": 1.75,
-          "c": "#777777",
-          "w": 1.25,
-          "h": 2,
-          "w2": 1.5,
-          "h2": 1,
-          "x2": -0.25
-        },
-        "1,14\n\n\n3,1"
-      ],
-      [
-        {
-          "x": 2.5,
-          "c": "#aaaaaa",
-          "w": 1.75
-        },
-        "2,0",
-        {
-          "c": "#cccccc"
-        },
-        "2,1",
-        "2,2",
-        "2,3",
-        "2,4",
-        "2,5",
-        "2,6",
-        "2,7",
-        "2,8",
-        "2,9",
-        "2,10",
-        "2,11",
-        {
-          "c": "#777777",
-          "w": 2.25
-        },
-        "2,13\n\n\n3,0",
-        {
-          "x": 0.75,
-          "c": "#cccccc"
-        },
-        "2,12\n\n\n3,1"
-      ],
-      [
-        {
-          "c": "#aaaaaa",
-          "w": 1.25
-        },
-        "3,0\n\n\n1,1",
-        {
-          "c": "#cccccc"
-        },
-        "3,1\n\n\n1,1",
-        {
-          "x": 0.25,
-          "c": "#aaaaaa",
-          "w": 2.25
-        },
-        "3,0\n\n\n1,0",
-        {
-          "c": "#cccccc"
-        },
-        "3,2",
-        "3,3",
-        "3,4",
-        "3,5",
-        "3,6",
-        "3,7",
-        "3,8",
-        "3,9",
-        "3,10",
-        "3,11",
-        {
-          "c": "#aaaaaa",
-          "w": 2.75
-        },
-        "3,13\n\n\n2,0",
-        {
-          "x": 0.25,
-          "w": 1.75
-        },
-        "3,12\n\n\n2,1",
-        {
-          "c": "#cccccc"
-        },
-        "3,14\n\n\n2,1",
-        {
-          "x": 0.25
-        },
-        "3,12\n\n\n2,2",
-        {
-          "c": "#aaaaaa",
-          "w": 1.75
-        },
-        "3,13\n\n\n2,2"
-      ],
-      [
-        {
-          "x": 2.5,
-          "w": 1.5
-        },
-        "4,0",
-        "4,1",
-        {
-          "w": 1.5
-        },
-        "4,2",
-        {
-          "c": "#cccccc",
-          "w": 7
-        },
-        "4,6",
-        {
-          "c": "#aaaaaa"
-        },
-        "4,10",
-        "4,11",
-        "4,12",
-        "4,13"
-      ]
+      ["0,0", "1,0", "2,0", "3,0"],
+      ["4,0", "5,0", "6,0", "7,0"]
     ]
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
