### PR TITLE
First suppor for mode M65 and 75 v2

### DIFF
--- a/v3/mode/m65v2/m65v2.json
+++ b/v3/mode/m65v2/m65v2.json
@@ -1,0 +1,390 @@
+{
+  "name": "Mode M65V2",
+  "vendorId": "0x00DE",
+  "productId": "0x6665",
+  "matrix": {
+    "rows": 6,
+    "cols": 16
+  },
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    "qmk_rgblight",
+    {
+      "label": "Indicators",
+      "content": [
+        {
+          "label": "Right indicator",
+          "content": [
+            {
+              "label": "Enable right indicator",
+              "type": "toggle",
+              "content": [
+                "id_ind1_enabled",
+                0,
+                1
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Brightness",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_ind1_brightness",
+                0,
+                2
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Color",
+              "type": "color",
+              "content": [
+                "id_ind1_color",
+                0,
+                3
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Function 1",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind1_func1",
+                0,
+                4
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Function 2",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind1_func2",
+                0,
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Left indicator",
+          "content": [
+            {
+              "label": "Enable central indicator",
+              "type": "toggle",
+              "content": [
+                "id_ind2_enabled",
+                0,
+                6
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Brightness",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_ind2_brightness",
+                0,
+                7
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Color",
+              "type": "color",
+              "content": [
+                "id_ind2_color",
+                0,
+                8
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Function 1",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind2_func1",
+                0,
+                9
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Function 2",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind2_func2",
+                0,
+                10
+              ]
+            }
+          ]
+        }
+      ]
+}
+],
+      "layouts": {
+          "labels": [
+            "Split backspace",
+            "ISO Enter",
+            "Split left shift",
+            "Tsangan bottom row"
+          ],
+          "keymap": [
+  [
+    {
+      "x": 2.25,
+      "c": "#777777"
+    },
+    "0,0",
+    {
+      "c": "#cccccc"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    "0,5",
+    "0,6",
+    "0,7",
+    "0,8",
+    "0,9",
+    "0,10",
+    "0,11",
+    "0,12",
+    {
+      "c": "#aaaaaa",
+      "w": 2
+    },
+    "0,13\n\n\n0,0",
+    {
+      "c": "#cccccc"
+    },
+    "0,15",
+    {
+      "x": 0.5
+    },
+    "0,13\n\n\n0,1",
+    "0,14\n\n\n0,1"
+  ],
+  [
+    {
+      "x": 2.25,
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "1,0",
+    {
+      "c": "#cccccc"
+    },
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "w": 1.5
+    },
+    "1,14\n\n\n1,0",
+    "1,15",
+    {
+      "x": 1.25,
+      "c": "#777777",
+      "w": 1.25,
+      "h": 2,
+      "w2": 1.5,
+      "h2": 1,
+      "x2": -0.25
+    },
+    "2,14\n\n\n1,1"
+  ],
+  [
+    {
+      "x": 2.25,
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "2,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    {
+      "c": "#777777",
+      "w": 2.25
+    },
+    "2,14\n\n\n1,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,15",
+    {
+      "x": 0.25
+    },
+    "2,13\n\n\n1,1"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "3,0\n\n\n2,1",
+    "3,1\n\n\n2,1",
+    {
+      "w": 2.25
+    },
+    "3,0\n\n\n2,0",
+    {
+      "c": "#cccccc"
+    },
+    "3,2",
+    "3,3",
+    "3,4",
+    "5,5",
+    "5,6",
+    "5,7",
+    "5,8",
+    "5,9",
+    "5,10",
+    "5,11",
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "5,12",
+    {
+      "c": "#cccccc"
+    },
+    "5,14",
+    "5,15"
+  ],
+  [
+    {
+      "x": 2.25,
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "4,0\n\n\n3,0",
+    "4,1\n\n\n3,0",
+    {
+      "w": 1.5
+    },
+    "4,2\n\n\n3,0",
+    {
+      "c": "#cccccc",
+      "w": 7
+    },
+    "4,6\n\n\n3,0",
+    {
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "4,11\n\n\n3,0",
+    {
+      "x": 0.5,
+      "c": "#cccccc"
+    },
+    "4,13",
+    "4,14",
+    "4,15"
+  ],
+  [
+    {
+      "x": 2.25,
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,0\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "4,1\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "4,2\n\n\n3,1",
+    {
+      "c": "#cccccc",
+      "w": 6.25
+    },
+    "4,6\n\n\n3,1",
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,10\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "4,11\n\n\n3,1"
+  ]
+]
+}
+}

--- a/v3/mode/m65v2/m65v2.json
+++ b/v3/mode/m65v2/m65v2.json
@@ -7,7 +7,7 @@
     "cols": 16
   },
   "keycodes": [
-    "qmk_lighting"
+    "qmk_rgblight_keycodes"
   ],
   "menus": [
     "qmk_rgblight",

--- a/v3/mode/m75v2/m75v2.json
+++ b/v3/mode/m75v2/m75v2.json
@@ -1,0 +1,422 @@
+{
+  "name": "Mode M75V2",
+  "vendorId": "0x00DE",
+  "productId": "0x6675",
+  "matrix": {
+    "rows": 7,
+    "cols": 16
+  },
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
+    "qmk_rgblight",
+    {
+      "label": "Indicators",
+      "content": [
+        {
+          "label": "Right indicator",
+          "content": [
+            {
+              "label": "Enable right indicator",
+              "type": "toggle",
+              "content": [
+                "id_ind1_enabled",
+                0,
+                1
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Brightness",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_ind1_brightness",
+                0,
+                2
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Color",
+              "type": "color",
+              "content": [
+                "id_ind1_color",
+                0,
+                3
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Function 1",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind1_func1",
+                0,
+                4
+              ]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "label": "Function 2",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind1_func2",
+                0,
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Left indicator",
+          "content": [
+            {
+              "label": "Enable central indicator",
+              "type": "toggle",
+              "content": [
+                "id_ind2_enabled",
+                0,
+                6
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Brightness",
+              "type": "range",
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_ind2_brightness",
+                0,
+                7
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Color",
+              "type": "color",
+              "content": [
+                "id_ind2_color",
+                0,
+                8
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Function 1",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind2_func1",
+                0,
+                9
+              ]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "label": "Function 2",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Caps Lock",
+                "Num Lock",
+                "Scroll Lock",
+                "Layer 0",
+                "Layer 1",
+                "Layer 2",
+                "Layer 3"
+              ],
+              "content": [
+                "id_ind2_func2",
+                0,
+                10
+              ]
+            }
+          ]
+        }
+      ]
+}
+],
+      "layouts": {
+          "labels": [
+            "Split backspace",
+            "ISO Enter",
+            "Split left shift",
+            "Tsangan bottom row"
+          ],
+          "keymap": 
+[
+  [
+    {
+      "x": 2.5,
+      "c": "#777777"
+    },
+    "0,0",
+    {
+      "x": 0.5,
+      "c": "#cccccc"
+    },
+    "0,1",
+    "0,2",
+    "0,3",
+    "0,4",
+    {
+      "x": 0.5,
+      "c": "#aaaaaa"
+    },
+    "0,6",
+    "0,7",
+    "0,8",
+    "0,9",
+    {
+      "x": 0.5,
+      "c": "#cccccc"
+    },
+    "0,10",
+    "0,11",
+    "0,12",
+    "0,13",
+    {
+      "x": 0.5
+    },
+    "0,15"
+  ],
+  [
+    {
+      "y": 0.25,
+      "x": 2.5
+    },
+    "1,0",
+    "1,1",
+    "1,2",
+    "1,3",
+    "1,4",
+    "1,5",
+    "1,6",
+    "1,7",
+    "1,8",
+    "1,9",
+    "1,10",
+    "1,11",
+    "1,12",
+    {
+      "c": "#aaaaaa",
+      "w": 2
+    },
+    "1,13\n\n\n0,0",
+    "1,15",
+    {
+      "x": 0.75
+    },
+    "1,13\n\n\n0,1",
+    "1,14\n\n\n0,1"
+  ],
+  [
+    {
+      "x": 2.5,
+      "w": 1.5
+    },
+    "2,0",
+    {
+      "c": "#cccccc"
+    },
+    "2,1",
+    "2,2",
+    "2,3",
+    "2,4",
+    "2,5",
+    "2,6",
+    "2,7",
+    "2,8",
+    "2,9",
+    "2,10",
+    "2,11",
+    "2,12",
+    {
+      "w": 1.5
+    },
+    "2,14\n\n\n1,0",
+    {
+      "c": "#aaaaaa"
+    },
+    "2,15",
+    {
+      "x": 1.5,
+      "c": "#777777",
+      "w": 1.25,
+      "h": 2,
+      "w2": 1.5,
+      "h2": 1,
+      "x2": -0.25
+    },
+    "3,14\n\n\n1,1"
+  ],
+  [
+    {
+      "x": 2.5,
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "3,0",
+    {
+      "c": "#cccccc"
+    },
+    "3,1",
+    "3,2",
+    "3,3",
+    "3,4",
+    "3,5",
+    "3,6",
+    "3,7",
+    "3,8",
+    "3,9",
+    "3,10",
+    "3,11",
+    {
+      "c": "#777777",
+      "w": 2.25
+    },
+    "3,14\n\n\n1,0",
+    {
+      "c": "#aaaaaa"
+    },
+    "3,15",
+    {
+      "x": 0.5,
+      "c": "#cccccc"
+    },
+    "3,12\n\n\n1,1"
+  ],
+  [
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "4,0\n\n\n2,1",
+    {
+      "c": "#cccccc"
+    },
+    "4,1\n\n\n2,1",
+    {
+      "x": 0.25,
+      "c": "#aaaaaa",
+      "w": 2.25
+    },
+    "4,0\n\n\n2,0",
+    {
+      "c": "#cccccc"
+    },
+    "4,2",
+    "4,3",
+    "4,4",
+    "4,5",
+    "4,6",
+    "4,7",
+    "4,8",
+    "4,9",
+    "4,10",
+    "4,11",
+    {
+      "c": "#aaaaaa",
+      "w": 1.75
+    },
+    "4,12",
+    "4,14",
+    "4,15"
+  ],
+  [
+    {
+      "x": 2.5,
+      "w": 1.5
+    },
+    "5,0\n\n\n3,0",
+    "5,1\n\n\n3,0",
+    {
+      "w": 1.5
+    },
+    "5,2\n\n\n3,0",
+    {
+      "c": "#cccccc",
+      "w": 7
+    },
+    "6,6\n\n\n3,0",
+    {
+      "c": "#aaaaaa",
+      "w": 1.5
+    },
+    "6,11\n\n\n3,0",
+    {
+      "x": 0.5
+    },
+    "6,13",
+    "6,14",
+    "6,15"
+  ],
+  [
+    {
+      "x": 2.5,
+      "w": 1.25
+    },
+    "5,0\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "5,1\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "5,2\n\n\n3,1",
+    {
+      "c": "#cccccc",
+      "w": 6.25
+    },
+    "6,6\n\n\n3,1",
+    {
+      "c": "#aaaaaa",
+      "w": 1.25
+    },
+    "6,10\n\n\n3,1",
+    {
+      "w": 1.25
+    },
+    "6,11\n\n\n3,1"
+  ]
+]
+}
+}

--- a/v3/mode/m75v2/m75v2.json
+++ b/v3/mode/m75v2/m75v2.json
@@ -7,7 +7,7 @@
     "cols": 16
   },
   "keycodes": [
-    "qmk_lighting"
+    "qmk_rgblight_keycodes"
   ],
   "menus": [
     "qmk_rgblight",


### PR DESCRIPTION

## Description

Adds support for MODE's M65 V2 and M75 V2.
## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/26049

## VIA Keymap Pull Request

https://github.com/the-via/qmk_userspace_via/pull/149

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
