### PR TITLE
Update to properly handle new json structures and types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 - [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
 - [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
 - [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
+- [ ] I have used explicit QMK lighting keycode modules instead of the legacy `qmk_lighting` module.
 - [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
 - [ ] I have tested this keyboard definition using VIA's "Design" tab.
 - [ ] I have tested this keyboard definition with firmware on a device.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "via-keyboards": "./bin/cli.js"
   },
   "scripts": {
+    "prebuild": "npm run validate:keycodes",
     "build": "tsx scripts/build-all.ts",
     "build-names": "tsx scripts/build-names.ts",
     "prettify-all": "prettier --write ./src ./v3",
-    "prettify-staged": "pretty-quick --staged"
+    "prettify-staged": "pretty-quick --staged",
+    "validate:keycodes": "tsx scripts/validate-keycode-modules.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-names.ts
+++ b/scripts/build-names.ts
@@ -1,13 +1,16 @@
 import stringify from 'json-stringify-pretty-compact';
 import fs from 'fs-extra';
-import {VIADefinitionV3} from '@the-via/reader';
+import {DefinitionName, VIADefinitionV3} from '@the-via/reader';
 import {getOutputPath} from './get-path';
+
+const getDefinitionNames = (name: DefinitionName): string[] =>
+  typeof name === 'string' ? [name] : name.options;
 
 export async function buildNames(definitions: VIADefinitionV3[]) {
   const outputPath = `${getOutputPath()}`;
 
   const names = definitions
-    .reduce((p, n) => [...p, n.name], [] as string[])
+    .flatMap(({name}) => getDefinitionNames(name))
     .sort();
 
   if (!(await fs.exists(outputPath))) {

--- a/scripts/validate-keycode-modules.ts
+++ b/scripts/validate-keycode-modules.ts
@@ -1,0 +1,39 @@
+import fs from 'fs-extra';
+import {globSync} from 'glob';
+import path from 'path';
+import {getDefinitionsPath} from './get-path';
+
+const LEGACY_LIGHTING_MODULE = 'qmk_lighting';
+const EXPLICIT_LIGHTING_MODULES = [
+  'qmk_backlight_keycodes',
+  'qmk_rgblight_keycodes',
+  'qmk_rgb_matrix_keycodes',
+  'qmk_backlight_rgblight_keycodes',
+];
+
+const invalidDefinitions = globSync(getDefinitionsPath('v3'), {
+  absolute: true,
+}).flatMap((definitionPath) => {
+  const definition = fs.readJSONSync(definitionPath) as {
+    keycodes?: string[];
+  };
+
+  return definition.keycodes?.includes(LEGACY_LIGHTING_MODULE)
+    ? [path.relative(process.cwd(), definitionPath)]
+    : [];
+});
+
+if (invalidDefinitions.length > 0) {
+  console.error(
+    [
+      `${LEGACY_LIGHTING_MODULE} is a legacy compatibility fallback and is not accepted in remote v3 definitions.`,
+      `Use the lighting module or modules matching the keyboard firmware: ${EXPLICIT_LIGHTING_MODULES.join(', ')}.`,
+      '',
+      'Definitions using the legacy module:',
+      ...invalidDefinitions.map((definitionPath) => `- ${definitionPath}`),
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log('Validated v3 lighting keycode modules.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
