### PR TITLE
Add Positron Electronic OSUpad keyboard definition

### DIFF
--- a/src/positron_electronic/osupad/via.json
+++ b/src/positron_electronic/osupad/via.json
@@ -1,0 +1,20 @@
+{
+  "name": "OSUpad Clone VIA",
+  "vendorId": "0x1209",
+  "productId": "0x7050",
+  "firmwareVersion": 1,
+  "matrix": {
+    "rows": 2,
+    "cols": 3
+  },
+  "lighting": "qmk_rgblight",
+  "keycodes": ["qmk_lighting"],
+  "menus": ["qmk_rgblight"],
+  "layouts": {
+    "keymap": [
+      ["0,0", "0,1", "0,2"],
+      ["1,0", "1,1", "1,2"]
+    ]
+  }
+}
+


### PR DESCRIPTION
## Keyboard Info

- **Keyboard name:** Positron OSUpad
- **Vendor ID:** 0x1209
- **Product ID:** 0x7050
- **Firmware repository:** https://github.com/juarendra/OSUpad-QMK-VIA

## QMK Firmware PR

- https://github.com/qmk/qmk_firmware/pull/26399

## pid.codes allocation

- https://github.com/pidcodes/pidcodes.github.com/pull/1258

## Notes

A 2x3 hotswap mechanical macropad with RGB lighting from Positron Electronic.
This definition follows the VIA v3 specification and uses the open-source
VID 0x1209 (pid.codes).