### PR TITLE
More update for module

### DIFF
--- a/v3/cipulot/60xt/60xt.json
+++ b/v3/cipulot/60xt/60xt.json
@@ -2,10 +2,1475 @@
   "name": "Cipulot 60XT",
   "vendorId": "0x6369",
   "productId": "0x6BC2",
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "matrix": {
     "rows": 5,
     "cols": 16
   },
+  "menus": [
+    {
+      "showIf": "{id_firmware_version} >= 1",
+      "label": "Advanced Features",
+      "content": [
+        {
+          "label": "SOCD",
+          "content": [
+            {
+              "label": "Pair #1 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_1_mode", 0, 1]
+            },
+            {
+              "showIf": "{id_socd_pair_1_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 2]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 3]
+                }
+              ]
+            },
+            {
+              "label": "Pair #2 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_2_mode", 0, 4]
+            },
+            {
+              "showIf": "{id_socd_pair_2_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 5]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 6]
+                }
+              ]
+            },
+            {
+              "label": "Pair #3 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_3_mode", 0, 7]
+            },
+            {
+              "showIf": "{id_socd_pair_3_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 8]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 9]
+                }
+              ]
+            },
+            {
+              "label": "Pair #4 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_4_mode", 0, 10]
+            },
+            {
+              "showIf": "{id_socd_pair_4_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 11]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 12]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Tap Dance",
+      "content": [
+        {
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "showIf": "{id_firmware_version} >= 1",
+      "label": "Board System",
+      "content": [
+        {
+          "label": "Board Maintenance",
+          "content": [
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "content": [
+                {
+                  "label": "Firmware Version",
+                  "type": "label",
+                  "content": ["id_firmware_version_text", 0, 15]
+                },
+                {
+                  "label": "Firmware Build",
+                  "type": "label",
+                  "content": ["id_firmware_build_text", 0, 16]
+                }
+              ]
+            },
+            {
+              "label": "Flash Mode",
+              "type": "button",
+              "options": [0],
+              "content": ["id_flash_mode", 0, 13]
+            },
+            {
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 14]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "layouts": {
     "labels": [
       "Split Backspace",
@@ -14,12 +1479,7 @@
       "ISO",
       "Vertical 2U #1",
       "Vertical 2U #2",
-      [
-        "Bottom Row",
-        "7U WK",
-        "7U WKL",
-        "7U HHKB"
-      ]
+      ["Bottom Row", "7U WK", "7U WKL", "7U HHKB"]
     ],
     "keymap": [
       [

--- a/v3/cipulot/des_60/des_60.json
+++ b/v3/cipulot/des_60/des_60.json
@@ -1,0 +1,7000 @@
+{
+  "name": "NEVEREST 60",
+  "vendorId": "0x6369",
+  "productId": "0x6BB7",
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    },
+    {
+      "name": "DKS(0)",
+      "title": "Dynamic Keystroke slot 0",
+      "shortName": "DKS\n0"
+    },
+    {
+      "name": "DKS(1)",
+      "title": "Dynamic Keystroke slot 1",
+      "shortName": "DKS\n1"
+    },
+    {
+      "name": "DKS(2)",
+      "title": "Dynamic Keystroke slot 2",
+      "shortName": "DKS\n2"
+    },
+    {
+      "name": "DKS(3)",
+      "title": "Dynamic Keystroke slot 3",
+      "shortName": "DKS\n3"
+    },
+    {
+      "name": "DKS(4)",
+      "title": "Dynamic Keystroke slot 4",
+      "shortName": "DKS\n4"
+    },
+    {
+      "name": "DKS(5)",
+      "title": "Dynamic Keystroke slot 5",
+      "shortName": "DKS\n5"
+    },
+    {
+      "name": "DKS(6)",
+      "title": "Dynamic Keystroke slot 6",
+      "shortName": "DKS\n6"
+    },
+    {
+      "name": "DKS(7)",
+      "title": "Dynamic Keystroke slot 7",
+      "shortName": "DKS\n7"
+    },
+    {
+      "name": "DKS(8)",
+      "title": "Dynamic Keystroke slot 8",
+      "shortName": "DKS\n8"
+    },
+    {
+      "name": "DKS(9)",
+      "title": "Dynamic Keystroke slot 9",
+      "shortName": "DKS\n9"
+    },
+    {
+      "name": "DKS(10)",
+      "title": "Dynamic Keystroke slot 10",
+      "shortName": "DKS\n10"
+    },
+    {
+      "name": "DKS(11)",
+      "title": "Dynamic Keystroke slot 11",
+      "shortName": "DKS\n11"
+    },
+    {
+      "name": "DKS(12)",
+      "title": "Dynamic Keystroke slot 12",
+      "shortName": "DKS\n12"
+    },
+    {
+      "name": "DKS(13)",
+      "title": "Dynamic Keystroke slot 13",
+      "shortName": "DKS\n13"
+    },
+    {
+      "name": "DKS(14)",
+      "title": "Dynamic Keystroke slot 14",
+      "shortName": "DKS\n14"
+    },
+    {
+      "name": "DKS(15)",
+      "title": "Dynamic Keystroke slot 15",
+      "shortName": "DKS\n15"
+    },
+    {
+      "name": "GC_LS_UP",
+      "title": "Controller left stick up",
+      "shortName": "LS\nUP"
+    },
+    {
+      "name": "GC_LS_DOWN",
+      "title": "Controller left stick down",
+      "shortName": "LS\nDOWN"
+    },
+    {
+      "name": "GC_LS_LEFT",
+      "title": "Controller left stick left",
+      "shortName": "LS\nLEFT"
+    },
+    {
+      "name": "GC_LS_RIGHT",
+      "title": "Controller left stick right",
+      "shortName": "LS\nRIGHT"
+    },
+    {
+      "name": "GC_RS_UP",
+      "title": "Controller right stick up",
+      "shortName": "RS\nUP"
+    },
+    {
+      "name": "GC_RS_DOWN",
+      "title": "Controller right stick down",
+      "shortName": "RS\nDOWN"
+    },
+    {
+      "name": "GC_RS_LEFT",
+      "title": "Controller right stick left",
+      "shortName": "RS\nLEFT"
+    },
+    {
+      "name": "GC_RS_RIGHT",
+      "title": "Controller right stick right",
+      "shortName": "RS\nRIGHT"
+    },
+    {
+      "name": "GC_L3",
+      "title": "Controller left stick click",
+      "shortName": "L3"
+    },
+    {
+      "name": "GC_R3",
+      "title": "Controller right stick click",
+      "shortName": "R3"
+    },
+    {
+      "name": "GC_LT",
+      "title": "Controller left trigger",
+      "shortName": "LT"
+    },
+    {
+      "name": "GC_RT",
+      "title": "Controller right trigger",
+      "shortName": "RT"
+    },
+    {
+      "name": "GC_DPAD_UP",
+      "title": "Controller D-pad up",
+      "shortName": "DPAD\nUP"
+    },
+    {
+      "name": "GC_DPAD_DOWN",
+      "title": "Controller D-pad down",
+      "shortName": "DPAD\nDOWN"
+    },
+    {
+      "name": "GC_DPAD_LEFT",
+      "title": "Controller D-pad left",
+      "shortName": "DPAD\nLEFT"
+    },
+    {
+      "name": "GC_DPAD_RIGHT",
+      "title": "Controller D-pad right",
+      "shortName": "DPAD\nRIGHT"
+    },
+    {
+      "name": "GC_A",
+      "title": "Controller A button",
+      "shortName": "PAD\nA"
+    },
+    {
+      "name": "GC_B",
+      "title": "Controller B button",
+      "shortName": "PAD\nB"
+    },
+    {
+      "name": "GC_X",
+      "title": "Controller X button",
+      "shortName": "PAD\nX"
+    },
+    {
+      "name": "GC_Y",
+      "title": "Controller Y button",
+      "shortName": "PAD\nY"
+    },
+    {
+      "name": "GC_LB",
+      "title": "Controller left bumper",
+      "shortName": "LB"
+    },
+    {
+      "name": "GC_RB",
+      "title": "Controller right bumper",
+      "shortName": "RB"
+    },
+    {
+      "name": "GC_VIEW",
+      "title": "Controller View button",
+      "shortName": "PAD\nVIEW"
+    },
+    {
+      "name": "GC_MENU",
+      "title": "Controller Menu button",
+      "shortName": "PAD\nMENU"
+    },
+    {
+      "name": "GC_GUIDE",
+      "title": "Controller Guide (Xbox) button",
+      "shortName": "PAD\nGUIDE"
+    }
+  ],
+  "matrix": {
+    "rows": 4,
+    "cols": 15
+  },
+  "menus": [
+    {
+      "label": "Switch Configuration",
+      "content": [
+        {
+          "label": "Actuation",
+          "content": [
+            {
+              "label": "Mode",
+              "type": "dropdown",
+              "options": ["APC", "Rapid Trigger"],
+              "content": ["id_actuation_mode", 0, 1]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 0",
+              "content": [
+                {
+                  "label": "Actuation threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": ">=",
+                      "reference": "id_apc_release_threshold",
+                      "offset": 50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_actuation_threshold", 0, 2]
+                },
+                {
+                  "label": "Release threshold (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "constraints": [
+                    {
+                      "operator": "<=",
+                      "reference": "id_apc_actuation_threshold",
+                      "offset": -50,
+                      "onViolation": "push"
+                    }
+                  ],
+                  "content": ["id_apc_release_threshold", 0, 3]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [0],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            },
+            {
+              "showIf": "{id_actuation_mode} == 1",
+              "content": [
+                {
+                  "label": "Initial deadzone offset (1-1023)",
+                  "type": "range",
+                  "options": [1, 1023],
+                  "content": ["id_rt_initial_deadzone_offset", 0, 5]
+                },
+                {
+                  "label": "Actuation offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_actuation_offset", 0, 6]
+                },
+                {
+                  "label": "Release offset (1-255)",
+                  "type": "range",
+                  "options": [1, 255],
+                  "content": ["id_rt_release_offset", 0, 7]
+                },
+                {
+                  "label": "Apply & save changes",
+                  "type": "button",
+                  "options": [1],
+                  "content": ["id_save_threshold_data", 0, 4]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Calibration",
+          "content": [
+            {
+              "label": "Board Calibration",
+              "type": "toggle",
+              "content": ["id_bottoming_calibration", 0, 8]
+            },
+            {
+              "showIf": "{id_bottoming_calibration} == 0",
+              "label": "Print calibration data to console",
+              "type": "button",
+              "options": [0],
+              "content": ["id_show_calibration_data", 0, 10]
+            },
+            {
+              "showIf": "{id_bottoming_calibration} == 0",
+              "label": "Clear bottom-out calibration data",
+              "type": "button",
+              "options": [0],
+              "content": ["id_clear_bottoming_calibration_data", 0, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Tap Dance",
+      "content": [
+        {
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "SOCD",
+      "content": [
+        {
+          "label": "SOCD Settings",
+          "content": [
+            {
+              "label": "Pair #1 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_1_mode", 0, 12]
+            },
+            {
+              "showIf": "{id_socd_pair_1_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 13]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 14]
+                }
+              ]
+            },
+            {
+              "label": "Pair #2 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_2_mode", 0, 15]
+            },
+            {
+              "showIf": "{id_socd_pair_2_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 16]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 17]
+                }
+              ]
+            },
+            {
+              "label": "Pair #3 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_3_mode", 0, 18]
+            },
+            {
+              "showIf": "{id_socd_pair_3_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 19]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 20]
+                }
+              ]
+            },
+            {
+              "label": "Pair #4 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_4_mode", 0, 21]
+            },
+            {
+              "showIf": "{id_socd_pair_4_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 22]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 23]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "DKS",
+      "content": [
+        {
+          "label": "DKS General Settings",
+          "content": [
+            {
+              "label": "Enable Dynamic Keystrokes",
+              "type": "toggle",
+              "content": ["id_dks_enabled", 11, 1]
+            },
+            {
+              "label": "Reset all DKS slots",
+              "type": "button",
+              "options": [0],
+              "content": ["id_dks_reset_all", 11, 0]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 0 - DKS(0)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[0][0]", 11, 2, 0, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[0][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[0][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[0][1]", 11, 2, 0, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[0][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[0][2]", 11, 2, 0, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[0][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[0][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[0][3]", 11, 2, 0, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[0][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_0_0", 11, 3, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_0.0} != 0 || {id_dks_keycode_0_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][0][0]", 11, 4, 0, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_0.0} != 0 || {id_dks_keycode_0_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][1][0]", 11, 4, 0, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_0.0} != 0 || {id_dks_keycode_0_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][2][0]", 11, 4, 0, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_0.0} != 0 || {id_dks_keycode_0_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][3][0]", 11, 4, 0, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_0_1", 11, 3, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_1.0} != 0 || {id_dks_keycode_0_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][0][1]", 11, 4, 0, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_1.0} != 0 || {id_dks_keycode_0_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][1][1]", 11, 4, 0, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_1.0} != 0 || {id_dks_keycode_0_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][2][1]", 11, 4, 0, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_1.0} != 0 || {id_dks_keycode_0_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][3][1]", 11, 4, 0, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_0_2", 11, 3, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_2.0} != 0 || {id_dks_keycode_0_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][0][2]", 11, 4, 0, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_2.0} != 0 || {id_dks_keycode_0_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][1][2]", 11, 4, 0, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_2.0} != 0 || {id_dks_keycode_0_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][2][2]", 11, 4, 0, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_2.0} != 0 || {id_dks_keycode_0_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][3][2]", 11, 4, 0, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_0_3", 11, 3, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_3.0} != 0 || {id_dks_keycode_0_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][0][3]", 11, 4, 0, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_3.0} != 0 || {id_dks_keycode_0_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][1][3]", 11, 4, 0, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_3.0} != 0 || {id_dks_keycode_0_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][2][3]", 11, 4, 0, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_0_3.0} != 0 || {id_dks_keycode_0_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[0][3][3]", 11, 4, 0, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 1 - DKS(1)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[1][0]", 11, 2, 1, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[1][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[1][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[1][1]", 11, 2, 1, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[1][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[1][2]", 11, 2, 1, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[1][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[1][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[1][3]", 11, 2, 1, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[1][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_1_0", 11, 3, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_0.0} != 0 || {id_dks_keycode_1_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][0][0]", 11, 4, 1, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_0.0} != 0 || {id_dks_keycode_1_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][1][0]", 11, 4, 1, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_0.0} != 0 || {id_dks_keycode_1_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][2][0]", 11, 4, 1, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_0.0} != 0 || {id_dks_keycode_1_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][3][0]", 11, 4, 1, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_1_1", 11, 3, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_1.0} != 0 || {id_dks_keycode_1_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][0][1]", 11, 4, 1, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_1.0} != 0 || {id_dks_keycode_1_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][1][1]", 11, 4, 1, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_1.0} != 0 || {id_dks_keycode_1_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][2][1]", 11, 4, 1, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_1.0} != 0 || {id_dks_keycode_1_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][3][1]", 11, 4, 1, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_1_2", 11, 3, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_2.0} != 0 || {id_dks_keycode_1_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][0][2]", 11, 4, 1, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_2.0} != 0 || {id_dks_keycode_1_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][1][2]", 11, 4, 1, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_2.0} != 0 || {id_dks_keycode_1_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][2][2]", 11, 4, 1, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_2.0} != 0 || {id_dks_keycode_1_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][3][2]", 11, 4, 1, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_1_3", 11, 3, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_3.0} != 0 || {id_dks_keycode_1_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][0][3]", 11, 4, 1, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_3.0} != 0 || {id_dks_keycode_1_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][1][3]", 11, 4, 1, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_3.0} != 0 || {id_dks_keycode_1_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][2][3]", 11, 4, 1, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_1_3.0} != 0 || {id_dks_keycode_1_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[1][3][3]", 11, 4, 1, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 2 - DKS(2)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[2][0]", 11, 2, 2, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[2][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[2][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[2][1]", 11, 2, 2, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[2][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[2][2]", 11, 2, 2, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[2][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[2][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[2][3]", 11, 2, 2, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[2][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_2_0", 11, 3, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_0.0} != 0 || {id_dks_keycode_2_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][0][0]", 11, 4, 2, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_0.0} != 0 || {id_dks_keycode_2_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][1][0]", 11, 4, 2, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_0.0} != 0 || {id_dks_keycode_2_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][2][0]", 11, 4, 2, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_0.0} != 0 || {id_dks_keycode_2_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][3][0]", 11, 4, 2, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_2_1", 11, 3, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_1.0} != 0 || {id_dks_keycode_2_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][0][1]", 11, 4, 2, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_1.0} != 0 || {id_dks_keycode_2_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][1][1]", 11, 4, 2, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_1.0} != 0 || {id_dks_keycode_2_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][2][1]", 11, 4, 2, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_1.0} != 0 || {id_dks_keycode_2_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][3][1]", 11, 4, 2, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_2_2", 11, 3, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_2.0} != 0 || {id_dks_keycode_2_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][0][2]", 11, 4, 2, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_2.0} != 0 || {id_dks_keycode_2_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][1][2]", 11, 4, 2, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_2.0} != 0 || {id_dks_keycode_2_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][2][2]", 11, 4, 2, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_2.0} != 0 || {id_dks_keycode_2_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][3][2]", 11, 4, 2, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_2_3", 11, 3, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_3.0} != 0 || {id_dks_keycode_2_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][0][3]", 11, 4, 2, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_3.0} != 0 || {id_dks_keycode_2_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][1][3]", 11, 4, 2, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_3.0} != 0 || {id_dks_keycode_2_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][2][3]", 11, 4, 2, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_2_3.0} != 0 || {id_dks_keycode_2_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[2][3][3]", 11, 4, 2, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 3 - DKS(3)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[3][0]", 11, 2, 3, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[3][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[3][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[3][1]", 11, 2, 3, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[3][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[3][2]", 11, 2, 3, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[3][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[3][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[3][3]", 11, 2, 3, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[3][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_3_0", 11, 3, 3, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_0.0} != 0 || {id_dks_keycode_3_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][0][0]", 11, 4, 3, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_0.0} != 0 || {id_dks_keycode_3_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][1][0]", 11, 4, 3, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_0.0} != 0 || {id_dks_keycode_3_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][2][0]", 11, 4, 3, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_0.0} != 0 || {id_dks_keycode_3_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][3][0]", 11, 4, 3, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_3_1", 11, 3, 3, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_1.0} != 0 || {id_dks_keycode_3_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][0][1]", 11, 4, 3, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_1.0} != 0 || {id_dks_keycode_3_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][1][1]", 11, 4, 3, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_1.0} != 0 || {id_dks_keycode_3_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][2][1]", 11, 4, 3, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_1.0} != 0 || {id_dks_keycode_3_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][3][1]", 11, 4, 3, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_3_2", 11, 3, 3, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_2.0} != 0 || {id_dks_keycode_3_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][0][2]", 11, 4, 3, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_2.0} != 0 || {id_dks_keycode_3_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][1][2]", 11, 4, 3, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_2.0} != 0 || {id_dks_keycode_3_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][2][2]", 11, 4, 3, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_2.0} != 0 || {id_dks_keycode_3_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][3][2]", 11, 4, 3, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_3_3", 11, 3, 3, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_3.0} != 0 || {id_dks_keycode_3_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][0][3]", 11, 4, 3, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_3.0} != 0 || {id_dks_keycode_3_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][1][3]", 11, 4, 3, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_3.0} != 0 || {id_dks_keycode_3_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][2][3]", 11, 4, 3, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_3_3.0} != 0 || {id_dks_keycode_3_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[3][3][3]", 11, 4, 3, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 4 - DKS(4)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[4][0]", 11, 2, 4, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[4][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[4][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[4][1]", 11, 2, 4, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[4][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[4][2]", 11, 2, 4, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[4][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[4][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[4][3]", 11, 2, 4, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[4][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_4_0", 11, 3, 4, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_0.0} != 0 || {id_dks_keycode_4_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][0][0]", 11, 4, 4, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_0.0} != 0 || {id_dks_keycode_4_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][1][0]", 11, 4, 4, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_0.0} != 0 || {id_dks_keycode_4_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][2][0]", 11, 4, 4, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_0.0} != 0 || {id_dks_keycode_4_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][3][0]", 11, 4, 4, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_4_1", 11, 3, 4, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_1.0} != 0 || {id_dks_keycode_4_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][0][1]", 11, 4, 4, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_1.0} != 0 || {id_dks_keycode_4_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][1][1]", 11, 4, 4, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_1.0} != 0 || {id_dks_keycode_4_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][2][1]", 11, 4, 4, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_1.0} != 0 || {id_dks_keycode_4_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][3][1]", 11, 4, 4, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_4_2", 11, 3, 4, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_2.0} != 0 || {id_dks_keycode_4_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][0][2]", 11, 4, 4, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_2.0} != 0 || {id_dks_keycode_4_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][1][2]", 11, 4, 4, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_2.0} != 0 || {id_dks_keycode_4_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][2][2]", 11, 4, 4, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_2.0} != 0 || {id_dks_keycode_4_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][3][2]", 11, 4, 4, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_4_3", 11, 3, 4, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_3.0} != 0 || {id_dks_keycode_4_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][0][3]", 11, 4, 4, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_3.0} != 0 || {id_dks_keycode_4_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][1][3]", 11, 4, 4, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_3.0} != 0 || {id_dks_keycode_4_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][2][3]", 11, 4, 4, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_4_3.0} != 0 || {id_dks_keycode_4_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[4][3][3]", 11, 4, 4, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 5 - DKS(5)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[5][0]", 11, 2, 5, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[5][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[5][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[5][1]", 11, 2, 5, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[5][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[5][2]", 11, 2, 5, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[5][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[5][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[5][3]", 11, 2, 5, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[5][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_5_0", 11, 3, 5, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_0.0} != 0 || {id_dks_keycode_5_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][0][0]", 11, 4, 5, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_0.0} != 0 || {id_dks_keycode_5_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][1][0]", 11, 4, 5, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_0.0} != 0 || {id_dks_keycode_5_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][2][0]", 11, 4, 5, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_0.0} != 0 || {id_dks_keycode_5_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][3][0]", 11, 4, 5, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_5_1", 11, 3, 5, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_1.0} != 0 || {id_dks_keycode_5_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][0][1]", 11, 4, 5, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_1.0} != 0 || {id_dks_keycode_5_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][1][1]", 11, 4, 5, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_1.0} != 0 || {id_dks_keycode_5_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][2][1]", 11, 4, 5, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_1.0} != 0 || {id_dks_keycode_5_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][3][1]", 11, 4, 5, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_5_2", 11, 3, 5, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_2.0} != 0 || {id_dks_keycode_5_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][0][2]", 11, 4, 5, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_2.0} != 0 || {id_dks_keycode_5_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][1][2]", 11, 4, 5, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_2.0} != 0 || {id_dks_keycode_5_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][2][2]", 11, 4, 5, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_2.0} != 0 || {id_dks_keycode_5_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][3][2]", 11, 4, 5, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_5_3", 11, 3, 5, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_3.0} != 0 || {id_dks_keycode_5_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][0][3]", 11, 4, 5, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_3.0} != 0 || {id_dks_keycode_5_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][1][3]", 11, 4, 5, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_3.0} != 0 || {id_dks_keycode_5_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][2][3]", 11, 4, 5, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_5_3.0} != 0 || {id_dks_keycode_5_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[5][3][3]", 11, 4, 5, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 6 - DKS(6)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[6][0]", 11, 2, 6, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[6][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[6][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[6][1]", 11, 2, 6, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[6][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[6][2]", 11, 2, 6, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[6][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[6][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[6][3]", 11, 2, 6, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[6][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_6_0", 11, 3, 6, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_0.0} != 0 || {id_dks_keycode_6_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][0][0]", 11, 4, 6, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_0.0} != 0 || {id_dks_keycode_6_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][1][0]", 11, 4, 6, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_0.0} != 0 || {id_dks_keycode_6_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][2][0]", 11, 4, 6, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_0.0} != 0 || {id_dks_keycode_6_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][3][0]", 11, 4, 6, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_6_1", 11, 3, 6, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_1.0} != 0 || {id_dks_keycode_6_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][0][1]", 11, 4, 6, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_1.0} != 0 || {id_dks_keycode_6_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][1][1]", 11, 4, 6, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_1.0} != 0 || {id_dks_keycode_6_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][2][1]", 11, 4, 6, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_1.0} != 0 || {id_dks_keycode_6_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][3][1]", 11, 4, 6, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_6_2", 11, 3, 6, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_2.0} != 0 || {id_dks_keycode_6_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][0][2]", 11, 4, 6, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_2.0} != 0 || {id_dks_keycode_6_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][1][2]", 11, 4, 6, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_2.0} != 0 || {id_dks_keycode_6_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][2][2]", 11, 4, 6, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_2.0} != 0 || {id_dks_keycode_6_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][3][2]", 11, 4, 6, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_6_3", 11, 3, 6, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_3.0} != 0 || {id_dks_keycode_6_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][0][3]", 11, 4, 6, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_3.0} != 0 || {id_dks_keycode_6_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][1][3]", 11, 4, 6, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_3.0} != 0 || {id_dks_keycode_6_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][2][3]", 11, 4, 6, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_6_3.0} != 0 || {id_dks_keycode_6_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[6][3][3]", 11, 4, 6, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 7 - DKS(7)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[7][0]", 11, 2, 7, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[7][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[7][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[7][1]", 11, 2, 7, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[7][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[7][2]", 11, 2, 7, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[7][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[7][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[7][3]", 11, 2, 7, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[7][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_7_0", 11, 3, 7, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_0.0} != 0 || {id_dks_keycode_7_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][0][0]", 11, 4, 7, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_0.0} != 0 || {id_dks_keycode_7_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][1][0]", 11, 4, 7, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_0.0} != 0 || {id_dks_keycode_7_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][2][0]", 11, 4, 7, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_0.0} != 0 || {id_dks_keycode_7_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][3][0]", 11, 4, 7, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_7_1", 11, 3, 7, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_1.0} != 0 || {id_dks_keycode_7_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][0][1]", 11, 4, 7, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_1.0} != 0 || {id_dks_keycode_7_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][1][1]", 11, 4, 7, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_1.0} != 0 || {id_dks_keycode_7_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][2][1]", 11, 4, 7, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_1.0} != 0 || {id_dks_keycode_7_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][3][1]", 11, 4, 7, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_7_2", 11, 3, 7, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_2.0} != 0 || {id_dks_keycode_7_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][0][2]", 11, 4, 7, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_2.0} != 0 || {id_dks_keycode_7_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][1][2]", 11, 4, 7, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_2.0} != 0 || {id_dks_keycode_7_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][2][2]", 11, 4, 7, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_2.0} != 0 || {id_dks_keycode_7_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][3][2]", 11, 4, 7, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_7_3", 11, 3, 7, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_3.0} != 0 || {id_dks_keycode_7_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][0][3]", 11, 4, 7, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_3.0} != 0 || {id_dks_keycode_7_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][1][3]", 11, 4, 7, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_3.0} != 0 || {id_dks_keycode_7_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][2][3]", 11, 4, 7, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_7_3.0} != 0 || {id_dks_keycode_7_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[7][3][3]", 11, 4, 7, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 8 - DKS(8)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[8][0]", 11, 2, 8, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[8][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[8][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[8][1]", 11, 2, 8, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[8][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[8][2]", 11, 2, 8, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[8][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[8][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[8][3]", 11, 2, 8, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[8][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_8_0", 11, 3, 8, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_0.0} != 0 || {id_dks_keycode_8_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][0][0]", 11, 4, 8, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_0.0} != 0 || {id_dks_keycode_8_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][1][0]", 11, 4, 8, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_0.0} != 0 || {id_dks_keycode_8_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][2][0]", 11, 4, 8, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_0.0} != 0 || {id_dks_keycode_8_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][3][0]", 11, 4, 8, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_8_1", 11, 3, 8, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_1.0} != 0 || {id_dks_keycode_8_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][0][1]", 11, 4, 8, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_1.0} != 0 || {id_dks_keycode_8_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][1][1]", 11, 4, 8, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_1.0} != 0 || {id_dks_keycode_8_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][2][1]", 11, 4, 8, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_1.0} != 0 || {id_dks_keycode_8_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][3][1]", 11, 4, 8, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_8_2", 11, 3, 8, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_2.0} != 0 || {id_dks_keycode_8_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][0][2]", 11, 4, 8, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_2.0} != 0 || {id_dks_keycode_8_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][1][2]", 11, 4, 8, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_2.0} != 0 || {id_dks_keycode_8_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][2][2]", 11, 4, 8, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_2.0} != 0 || {id_dks_keycode_8_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][3][2]", 11, 4, 8, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_8_3", 11, 3, 8, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_3.0} != 0 || {id_dks_keycode_8_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][0][3]", 11, 4, 8, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_3.0} != 0 || {id_dks_keycode_8_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][1][3]", 11, 4, 8, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_3.0} != 0 || {id_dks_keycode_8_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][2][3]", 11, 4, 8, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_8_3.0} != 0 || {id_dks_keycode_8_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[8][3][3]", 11, 4, 8, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 9 - DKS(9)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[9][0]", 11, 2, 9, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[9][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[9][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[9][1]", 11, 2, 9, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[9][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[9][2]", 11, 2, 9, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[9][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[9][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[9][3]", 11, 2, 9, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[9][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_9_0", 11, 3, 9, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_0.0} != 0 || {id_dks_keycode_9_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][0][0]", 11, 4, 9, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_0.0} != 0 || {id_dks_keycode_9_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][1][0]", 11, 4, 9, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_0.0} != 0 || {id_dks_keycode_9_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][2][0]", 11, 4, 9, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_0.0} != 0 || {id_dks_keycode_9_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][3][0]", 11, 4, 9, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_9_1", 11, 3, 9, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_1.0} != 0 || {id_dks_keycode_9_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][0][1]", 11, 4, 9, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_1.0} != 0 || {id_dks_keycode_9_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][1][1]", 11, 4, 9, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_1.0} != 0 || {id_dks_keycode_9_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][2][1]", 11, 4, 9, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_1.0} != 0 || {id_dks_keycode_9_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][3][1]", 11, 4, 9, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_9_2", 11, 3, 9, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_2.0} != 0 || {id_dks_keycode_9_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][0][2]", 11, 4, 9, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_2.0} != 0 || {id_dks_keycode_9_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][1][2]", 11, 4, 9, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_2.0} != 0 || {id_dks_keycode_9_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][2][2]", 11, 4, 9, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_2.0} != 0 || {id_dks_keycode_9_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][3][2]", 11, 4, 9, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_9_3", 11, 3, 9, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_3.0} != 0 || {id_dks_keycode_9_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][0][3]", 11, 4, 9, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_3.0} != 0 || {id_dks_keycode_9_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][1][3]", 11, 4, 9, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_3.0} != 0 || {id_dks_keycode_9_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][2][3]", 11, 4, 9, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_9_3.0} != 0 || {id_dks_keycode_9_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[9][3][3]", 11, 4, 9, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 10 - DKS(10)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[10][0]", 11, 2, 10, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[10][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[10][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[10][1]", 11, 2, 10, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[10][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[10][2]", 11, 2, 10, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[10][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[10][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[10][3]", 11, 2, 10, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[10][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_10_0", 11, 3, 10, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_0.0} != 0 || {id_dks_keycode_10_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][0][0]", 11, 4, 10, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_0.0} != 0 || {id_dks_keycode_10_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][1][0]", 11, 4, 10, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_0.0} != 0 || {id_dks_keycode_10_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][2][0]", 11, 4, 10, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_0.0} != 0 || {id_dks_keycode_10_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][3][0]", 11, 4, 10, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_10_1", 11, 3, 10, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_1.0} != 0 || {id_dks_keycode_10_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][0][1]", 11, 4, 10, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_1.0} != 0 || {id_dks_keycode_10_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][1][1]", 11, 4, 10, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_1.0} != 0 || {id_dks_keycode_10_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][2][1]", 11, 4, 10, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_1.0} != 0 || {id_dks_keycode_10_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][3][1]", 11, 4, 10, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_10_2", 11, 3, 10, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_2.0} != 0 || {id_dks_keycode_10_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][0][2]", 11, 4, 10, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_2.0} != 0 || {id_dks_keycode_10_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][1][2]", 11, 4, 10, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_2.0} != 0 || {id_dks_keycode_10_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][2][2]", 11, 4, 10, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_2.0} != 0 || {id_dks_keycode_10_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][3][2]", 11, 4, 10, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_10_3", 11, 3, 10, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_3.0} != 0 || {id_dks_keycode_10_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][0][3]", 11, 4, 10, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_3.0} != 0 || {id_dks_keycode_10_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][1][3]", 11, 4, 10, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_3.0} != 0 || {id_dks_keycode_10_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][2][3]", 11, 4, 10, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_10_3.0} != 0 || {id_dks_keycode_10_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[10][3][3]", 11, 4, 10, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 11 - DKS(11)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[11][0]", 11, 2, 11, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[11][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[11][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[11][1]", 11, 2, 11, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[11][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[11][2]", 11, 2, 11, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[11][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[11][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[11][3]", 11, 2, 11, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[11][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_11_0", 11, 3, 11, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_0.0} != 0 || {id_dks_keycode_11_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][0][0]", 11, 4, 11, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_0.0} != 0 || {id_dks_keycode_11_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][1][0]", 11, 4, 11, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_0.0} != 0 || {id_dks_keycode_11_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][2][0]", 11, 4, 11, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_0.0} != 0 || {id_dks_keycode_11_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][3][0]", 11, 4, 11, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_11_1", 11, 3, 11, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_1.0} != 0 || {id_dks_keycode_11_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][0][1]", 11, 4, 11, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_1.0} != 0 || {id_dks_keycode_11_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][1][1]", 11, 4, 11, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_1.0} != 0 || {id_dks_keycode_11_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][2][1]", 11, 4, 11, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_1.0} != 0 || {id_dks_keycode_11_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][3][1]", 11, 4, 11, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_11_2", 11, 3, 11, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_2.0} != 0 || {id_dks_keycode_11_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][0][2]", 11, 4, 11, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_2.0} != 0 || {id_dks_keycode_11_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][1][2]", 11, 4, 11, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_2.0} != 0 || {id_dks_keycode_11_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][2][2]", 11, 4, 11, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_2.0} != 0 || {id_dks_keycode_11_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][3][2]", 11, 4, 11, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_11_3", 11, 3, 11, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_3.0} != 0 || {id_dks_keycode_11_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][0][3]", 11, 4, 11, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_3.0} != 0 || {id_dks_keycode_11_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][1][3]", 11, 4, 11, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_3.0} != 0 || {id_dks_keycode_11_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][2][3]", 11, 4, 11, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_11_3.0} != 0 || {id_dks_keycode_11_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[11][3][3]", 11, 4, 11, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 12 - DKS(12)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[12][0]", 11, 2, 12, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[12][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[12][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[12][1]", 11, 2, 12, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[12][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[12][2]", 11, 2, 12, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[12][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[12][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[12][3]", 11, 2, 12, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[12][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_12_0", 11, 3, 12, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_0.0} != 0 || {id_dks_keycode_12_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][0][0]", 11, 4, 12, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_0.0} != 0 || {id_dks_keycode_12_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][1][0]", 11, 4, 12, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_0.0} != 0 || {id_dks_keycode_12_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][2][0]", 11, 4, 12, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_0.0} != 0 || {id_dks_keycode_12_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][3][0]", 11, 4, 12, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_12_1", 11, 3, 12, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_1.0} != 0 || {id_dks_keycode_12_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][0][1]", 11, 4, 12, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_1.0} != 0 || {id_dks_keycode_12_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][1][1]", 11, 4, 12, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_1.0} != 0 || {id_dks_keycode_12_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][2][1]", 11, 4, 12, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_1.0} != 0 || {id_dks_keycode_12_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][3][1]", 11, 4, 12, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_12_2", 11, 3, 12, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_2.0} != 0 || {id_dks_keycode_12_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][0][2]", 11, 4, 12, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_2.0} != 0 || {id_dks_keycode_12_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][1][2]", 11, 4, 12, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_2.0} != 0 || {id_dks_keycode_12_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][2][2]", 11, 4, 12, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_2.0} != 0 || {id_dks_keycode_12_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][3][2]", 11, 4, 12, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_12_3", 11, 3, 12, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_3.0} != 0 || {id_dks_keycode_12_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][0][3]", 11, 4, 12, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_3.0} != 0 || {id_dks_keycode_12_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][1][3]", 11, 4, 12, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_3.0} != 0 || {id_dks_keycode_12_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][2][3]", 11, 4, 12, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_12_3.0} != 0 || {id_dks_keycode_12_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[12][3][3]", 11, 4, 12, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 13 - DKS(13)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[13][0]", 11, 2, 13, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[13][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[13][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[13][1]", 11, 2, 13, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[13][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[13][2]", 11, 2, 13, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[13][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[13][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[13][3]", 11, 2, 13, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[13][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_13_0", 11, 3, 13, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_0.0} != 0 || {id_dks_keycode_13_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][0][0]", 11, 4, 13, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_0.0} != 0 || {id_dks_keycode_13_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][1][0]", 11, 4, 13, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_0.0} != 0 || {id_dks_keycode_13_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][2][0]", 11, 4, 13, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_0.0} != 0 || {id_dks_keycode_13_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][3][0]", 11, 4, 13, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_13_1", 11, 3, 13, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_1.0} != 0 || {id_dks_keycode_13_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][0][1]", 11, 4, 13, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_1.0} != 0 || {id_dks_keycode_13_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][1][1]", 11, 4, 13, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_1.0} != 0 || {id_dks_keycode_13_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][2][1]", 11, 4, 13, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_1.0} != 0 || {id_dks_keycode_13_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][3][1]", 11, 4, 13, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_13_2", 11, 3, 13, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_2.0} != 0 || {id_dks_keycode_13_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][0][2]", 11, 4, 13, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_2.0} != 0 || {id_dks_keycode_13_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][1][2]", 11, 4, 13, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_2.0} != 0 || {id_dks_keycode_13_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][2][2]", 11, 4, 13, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_2.0} != 0 || {id_dks_keycode_13_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][3][2]", 11, 4, 13, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_13_3", 11, 3, 13, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_3.0} != 0 || {id_dks_keycode_13_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][0][3]", 11, 4, 13, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_3.0} != 0 || {id_dks_keycode_13_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][1][3]", 11, 4, 13, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_3.0} != 0 || {id_dks_keycode_13_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][2][3]", 11, 4, 13, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_13_3.0} != 0 || {id_dks_keycode_13_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[13][3][3]", 11, 4, 13, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 14 - DKS(14)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[14][0]", 11, 2, 14, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[14][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[14][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[14][1]", 11, 2, 14, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[14][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[14][2]", 11, 2, 14, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[14][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[14][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[14][3]", 11, 2, 14, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[14][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_14_0", 11, 3, 14, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_0.0} != 0 || {id_dks_keycode_14_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][0][0]", 11, 4, 14, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_0.0} != 0 || {id_dks_keycode_14_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][1][0]", 11, 4, 14, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_0.0} != 0 || {id_dks_keycode_14_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][2][0]", 11, 4, 14, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_0.0} != 0 || {id_dks_keycode_14_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][3][0]", 11, 4, 14, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_14_1", 11, 3, 14, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_1.0} != 0 || {id_dks_keycode_14_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][0][1]", 11, 4, 14, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_1.0} != 0 || {id_dks_keycode_14_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][1][1]", 11, 4, 14, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_1.0} != 0 || {id_dks_keycode_14_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][2][1]", 11, 4, 14, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_1.0} != 0 || {id_dks_keycode_14_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][3][1]", 11, 4, 14, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_14_2", 11, 3, 14, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_2.0} != 0 || {id_dks_keycode_14_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][0][2]", 11, 4, 14, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_2.0} != 0 || {id_dks_keycode_14_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][1][2]", 11, 4, 14, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_2.0} != 0 || {id_dks_keycode_14_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][2][2]", 11, 4, 14, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_2.0} != 0 || {id_dks_keycode_14_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][3][2]", 11, 4, 14, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_14_3", 11, 3, 14, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_3.0} != 0 || {id_dks_keycode_14_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][0][3]", 11, 4, 14, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_3.0} != 0 || {id_dks_keycode_14_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][1][3]", 11, 4, 14, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_3.0} != 0 || {id_dks_keycode_14_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][2][3]", 11, 4, 14, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_14_3.0} != 0 || {id_dks_keycode_14_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[14][3][3]", 11, 4, 14, 3, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_dks_enabled} == 1",
+          "label": "DKS 15 - DKS(15)",
+          "content": [
+            {
+              "label": "Shallow press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[15][0]", 11, 2, 15, 0],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[15][3]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[15][2]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep press threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[15][1]", 11, 2, 15, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[15][2]",
+                  "offset": 50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Deep release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[15][2]", 11, 2, 15, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_dks_threshold[15][0]",
+                  "offset": 50,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[15][1]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Shallow release threshold (1-1023)",
+              "type": "range",
+              "options": [1, 1023],
+              "content": ["id_dks_threshold[15][3]", 11, 2, 15, 3],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_dks_threshold[15][0]",
+                  "offset": -50,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "label": "Output 1 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_15_0", 11, 3, 15, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_0.0} != 0 || {id_dks_keycode_15_0.1} != 0",
+              "label": "Output 1 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][0][0]", 11, 4, 15, 0, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_0.0} != 0 || {id_dks_keycode_15_0.1} != 0",
+              "label": "Output 1 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][1][0]", 11, 4, 15, 1, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_0.0} != 0 || {id_dks_keycode_15_0.1} != 0",
+              "label": "Output 1 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][2][0]", 11, 4, 15, 2, 0]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_0.0} != 0 || {id_dks_keycode_15_0.1} != 0",
+              "label": "Output 1 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][3][0]", 11, 4, 15, 3, 0]
+            },
+            {
+              "label": "Output 2 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_15_1", 11, 3, 15, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_1.0} != 0 || {id_dks_keycode_15_1.1} != 0",
+              "label": "Output 2 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][0][1]", 11, 4, 15, 0, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_1.0} != 0 || {id_dks_keycode_15_1.1} != 0",
+              "label": "Output 2 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][1][1]", 11, 4, 15, 1, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_1.0} != 0 || {id_dks_keycode_15_1.1} != 0",
+              "label": "Output 2 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][2][1]", 11, 4, 15, 2, 1]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_1.0} != 0 || {id_dks_keycode_15_1.1} != 0",
+              "label": "Output 2 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][3][1]", 11, 4, 15, 3, 1]
+            },
+            {
+              "label": "Output 3 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_15_2", 11, 3, 15, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_2.0} != 0 || {id_dks_keycode_15_2.1} != 0",
+              "label": "Output 3 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][0][2]", 11, 4, 15, 0, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_2.0} != 0 || {id_dks_keycode_15_2.1} != 0",
+              "label": "Output 3 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][1][2]", 11, 4, 15, 1, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_2.0} != 0 || {id_dks_keycode_15_2.1} != 0",
+              "label": "Output 3 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][2][2]", 11, 4, 15, 2, 2]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_2.0} != 0 || {id_dks_keycode_15_2.1} != 0",
+              "label": "Output 3 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][3][2]", 11, 4, 15, 3, 2]
+            },
+            {
+              "label": "Output 4 keycode",
+              "type": "keycode",
+              "content": ["id_dks_keycode_15_3", 11, 3, 15, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_3.0} != 0 || {id_dks_keycode_15_3.1} != 0",
+              "label": "Output 4 - Shallow press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][0][3]", 11, 4, 15, 0, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_3.0} != 0 || {id_dks_keycode_15_3.1} != 0",
+              "label": "Output 4 - Deep press",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][1][3]", 11, 4, 15, 1, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_3.0} != 0 || {id_dks_keycode_15_3.1} != 0",
+              "label": "Output 4 - Deep release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][2][3]", 11, 4, 15, 2, 3]
+            },
+            {
+              "showIf": "{id_dks_keycode_15_3.0} != 0 || {id_dks_keycode_15_3.1} != 0",
+              "label": "Output 4 - Shallow release",
+              "type": "dropdown",
+              "options": [
+                "None",
+                "Press",
+                "Release",
+                "Tap",
+                "Release and press again"
+              ],
+              "content": ["id_dks_action[15][3][3]", 11, 4, 15, 3, 3]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 5",
+      "label": "Controller",
+      "content": [
+        {
+          "label": "General",
+          "content": [
+            {
+              "label": "Enable controller",
+              "type": "toggle",
+              "content": ["id_controller_enabled", 12, 1]
+            },
+            {
+              "showIf": "{id_controller_enabled} == 1",
+              "label": "Protocol",
+              "type": "dropdown",
+              "options": ["Native HID", "XInput"],
+              "content": ["id_controller_protocol", 12, 2]
+            },
+            {
+              "showIf": "{id_controller_enabled} == 1",
+              "label": "Note",
+              "type": "label",
+              "content": [
+                "Changing protocol briefly restarts the USB connection."
+              ]
+            },
+            {
+              "showIf": "{id_controller_enabled} == 1",
+              "label": "Enable normal keyboard keys",
+              "type": "toggle",
+              "content": ["id_controller_keyboard", 12, 3]
+            },
+            {
+              "showIf": "{id_controller_enabled} == 1",
+              "label": "Calibrate controller dead zones (release all assigned controller keys)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_controller_calibrate", 12, 6]
+            },
+            {
+              "label": "Reset controller settings",
+              "type": "button",
+              "options": [0],
+              "content": ["id_controller_reset", 12, 0]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_controller_enabled} == 1",
+          "label": "Stick Behavior",
+          "content": [
+            {
+              "label": "Transition speed",
+              "type": "dropdown",
+              "options": ["Fast", "Normal", "Smooth"],
+              "content": ["id_controller_transition_speed", 12, 11]
+            },
+            {
+              "label": "Center hysteresis",
+              "type": "dropdown",
+              "options": ["Off", "Low", "Normal", "High"],
+              "content": ["id_controller_hysteresis", 12, 8]
+            },
+            {
+              "label": "Bottom-out stabilization",
+              "type": "dropdown",
+              "options": ["Off", "Low", "Normal", "High"],
+              "content": ["id_controller_bottomout", 12, 9]
+            },
+            {
+              "label": "Response curve",
+              "type": "dropdown",
+              "options": ["Linear", "Custom"],
+              "content": ["id_controller_curve_mode", 12, 4]
+            },
+            {
+              "showIf": "{id_controller_curve_mode} == 1",
+              "label": "Output at 25% travel (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_curve_point_1", 12, 5, 0],
+              "constraints": [
+                {
+                  "operator": "<=",
+                  "reference": "id_controller_curve_point_2",
+                  "offset": -10,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "showIf": "{id_controller_curve_mode} == 1",
+              "label": "Output at 50% travel (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_curve_point_2", 12, 5, 1],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_controller_curve_point_1",
+                  "offset": 10,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_controller_curve_point_3",
+                  "offset": -10,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "showIf": "{id_controller_curve_mode} == 1",
+              "label": "Output at 75% travel (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_curve_point_3", 12, 5, 2],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_controller_curve_point_2",
+                  "offset": 10,
+                  "onViolation": "push"
+                },
+                {
+                  "operator": "<=",
+                  "reference": "id_controller_curve_point_4",
+                  "offset": -10,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "showIf": "{id_controller_curve_mode} == 1",
+              "label": "Output at 100% travel (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_curve_point_4", 12, 5, 3],
+              "constraints": [
+                {
+                  "operator": ">=",
+                  "reference": "id_controller_curve_point_3",
+                  "offset": 10,
+                  "onViolation": "push"
+                }
+              ]
+            },
+            {
+              "showIf": "{id_controller_curve_mode} == 1",
+              "label": "Apply & save curve changes",
+              "type": "button",
+              "options": [0],
+              "content": ["id_controller_curve_save", 12, 14]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_controller_enabled} == 1",
+          "label": "Left Stick",
+          "content": [
+            {
+              "label": "X effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_lx", 12, 7, 0]
+            },
+            {
+              "label": "Y effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_ly", 12, 7, 1]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_controller_enabled} == 1",
+          "label": "Right Stick",
+          "content": [
+            {
+              "label": "X effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_rx", 12, 7, 2]
+            },
+            {
+              "label": "Y effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_ry", 12, 7, 3]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_controller_enabled} == 1",
+          "label": "Left Trigger",
+          "content": [
+            {
+              "label": "Full-press point (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_left_trigger_full_press", 12, 12]
+            },
+            {
+              "label": "Effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_lt", 12, 7, 4]
+            }
+          ]
+        },
+        {
+          "showIf": "{id_controller_enabled} == 1",
+          "label": "Right Trigger",
+          "content": [
+            {
+              "label": "Full-press point (%)",
+              "type": "range",
+              "options": [0, 100],
+              "content": ["id_controller_right_trigger_full_press", 12, 13]
+            },
+            {
+              "label": "Effective dead zone (0.1%)",
+              "type": "range",
+              "options": [0, 275],
+              "content": ["id_controller_deadzone_rt", 12, 7, 5]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 4",
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
+      "label": "System",
+      "content": [
+        {
+          "label": "Maintenance",
+          "content": [
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "label": "Firmware Version",
+              "type": "label",
+              "content": ["id_firmware_version_text", 0, 26]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "label": "Firmware build date",
+              "type": "label",
+              "content": ["id_firmware_build_text", 0, 27]
+            },
+            {
+              "label": "Enter bootloader",
+              "type": "button",
+              "options": [0],
+              "content": ["id_flash_mode", 0, 24]
+            },
+            {
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 25]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layouts": {
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        "0,1",
+        {
+          "c": "#cccccc"
+        },
+        "1,1",
+        "0,2",
+        "3,2",
+        "0,4",
+        "1,4",
+        "2,4",
+        "0,6",
+        "0,11",
+        "1,11",
+        "2,11",
+        "0,12",
+        "1,12",
+        "2,12",
+        {
+          "c": "#aaaaaa"
+        },
+        "0,13"
+      ],
+      [
+        {
+          "w": 1.5
+        },
+        "2,1",
+        {
+          "c": "#cccccc"
+        },
+        "3,1",
+        "1,2",
+        "2,2",
+        "3,4",
+        "1,6",
+        "2,6",
+        "0,9",
+        "1,9",
+        "2,9",
+        "3,11",
+        "3,12",
+        "1,13",
+        {
+          "w": 1.5
+        },
+        "2,13"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "0,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,0",
+        "2,0",
+        "0,3",
+        "0,5",
+        "0,7",
+        "3,6",
+        "3,9",
+        "0,10",
+        "1,10",
+        "0,8",
+        "0,14",
+        {
+          "c": "#777777",
+          "w": 2.25
+        },
+        "1,14"
+      ],
+      [
+        {
+          "c": "#aaaaaa",
+          "w": 2.25
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        "1,3",
+        "1,5",
+        "2,5",
+        "3,5",
+        "1,7",
+        "2,7",
+        "2,10",
+        "3,10",
+        "1,8",
+        "2,8",
+        {
+          "c": "#aaaaaa",
+          "w": 1.75
+        },
+        "2,14",
+        {
+          "c": "#cccccc"
+        },
+        "3,13"
+      ],
+      [
+        {
+          "x": 1.5,
+          "c": "#aaaaaa"
+        },
+        "3,3",
+        {
+          "w": 1.5
+        },
+        "2,3",
+        {
+          "c": "#cccccc",
+          "w": 6
+        },
+        "3,7",
+        {
+          "c": "#aaaaaa",
+          "w": 1.5
+        },
+        "3,8",
+        "3,14"
+      ]
+    ]
+  }
+}

--- a/v3/cipulot/je_bae_ted/mx_je_bae_ted.json
+++ b/v3/cipulot/je_bae_ted/mx_je_bae_ted.json
@@ -2,10 +2,1475 @@
   "name": "MX Je-BAE-Ted",
   "vendorId": "0x6369",
   "productId": "0x6BBB",
+  "customKeycodes": [
+    {
+      "name": "TD(0)",
+      "title": "Tap Dance slot 0",
+      "shortName": "TD\n0"
+    },
+    {
+      "name": "TD(1)",
+      "title": "Tap Dance slot 1",
+      "shortName": "TD\n1"
+    },
+    {
+      "name": "TD(2)",
+      "title": "Tap Dance slot 2",
+      "shortName": "TD\n2"
+    },
+    {
+      "name": "TD(3)",
+      "title": "Tap Dance slot 3",
+      "shortName": "TD\n3"
+    },
+    {
+      "name": "TD(4)",
+      "title": "Tap Dance slot 4",
+      "shortName": "TD\n4"
+    },
+    {
+      "name": "TD(5)",
+      "title": "Tap Dance slot 5",
+      "shortName": "TD\n5"
+    },
+    {
+      "name": "TD(6)",
+      "title": "Tap Dance slot 6",
+      "shortName": "TD\n6"
+    },
+    {
+      "name": "TD(7)",
+      "title": "Tap Dance slot 7",
+      "shortName": "TD\n7"
+    },
+    {
+      "name": "TD(8)",
+      "title": "Tap Dance slot 8",
+      "shortName": "TD\n8"
+    },
+    {
+      "name": "TD(9)",
+      "title": "Tap Dance slot 9",
+      "shortName": "TD\n9"
+    },
+    {
+      "name": "TD(10)",
+      "title": "Tap Dance slot 10",
+      "shortName": "TD\n10"
+    },
+    {
+      "name": "TD(11)",
+      "title": "Tap Dance slot 11",
+      "shortName": "TD\n11"
+    },
+    {
+      "name": "TD(12)",
+      "title": "Tap Dance slot 12",
+      "shortName": "TD\n12"
+    },
+    {
+      "name": "TD(13)",
+      "title": "Tap Dance slot 13",
+      "shortName": "TD\n13"
+    },
+    {
+      "name": "TD(14)",
+      "title": "Tap Dance slot 14",
+      "shortName": "TD\n14"
+    },
+    {
+      "name": "TD(15)",
+      "title": "Tap Dance slot 15",
+      "shortName": "TD\n15"
+    },
+    {
+      "name": "OS_LCTL",
+      "title": "One-Shot Left Control",
+      "shortName": "OS\nLCTL"
+    },
+    {
+      "name": "OS_LSFT",
+      "title": "One-Shot Left Shift",
+      "shortName": "OS\nLSFT"
+    },
+    {
+      "name": "OS_LALT",
+      "title": "One-Shot Left Alt",
+      "shortName": "OS\nLALT"
+    },
+    {
+      "name": "OS_LGUI",
+      "title": "One-Shot Left GUI",
+      "shortName": "OS\nLGUI"
+    },
+    {
+      "name": "OS_RCTL",
+      "title": "One-Shot Right Control",
+      "shortName": "OS\nRCTL"
+    },
+    {
+      "name": "OS_RSFT",
+      "title": "One-Shot Right Shift",
+      "shortName": "OS\nRSFT"
+    },
+    {
+      "name": "OS_RALT",
+      "title": "One-Shot Right Alt",
+      "shortName": "OS\nRALT"
+    },
+    {
+      "name": "OS_RGUI",
+      "title": "One-Shot Right GUI",
+      "shortName": "OS\nRGUI"
+    },
+    {
+      "name": "OS_ON",
+      "title": "Enable one-shot keys",
+      "shortName": "OS\nON"
+    },
+    {
+      "name": "OS_OFF",
+      "title": "Disable One-Shot keys",
+      "shortName": "OS\nOFF"
+    },
+    {
+      "name": "OS_TOGG",
+      "title": "Toggle One-Shot keys",
+      "shortName": "OS\nTOGG"
+    },
+    {
+      "name": "OS_MEH",
+      "title": "One-Shot Left Control, Shift and Alt",
+      "shortName": "OS\nMEH"
+    },
+    {
+      "name": "OS_HYPR",
+      "title": "One-Shot Left Control, Shift, Alt and GUI",
+      "shortName": "OS\nHYPR"
+    },
+    {
+      "name": "QK_LOCK",
+      "title": "Lock or unlock the next key pressed",
+      "shortName": "KEY\nLOCK"
+    }
+  ],
   "matrix": {
     "rows": 2,
     "cols": 1
   },
+  "menus": [
+    {
+      "showIf": "{id_firmware_version} >= 1",
+      "label": "Advanced Features",
+      "content": [
+        {
+          "label": "SOCD",
+          "content": [
+            {
+              "label": "Pair #1 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_1_mode", 0, 1]
+            },
+            {
+              "showIf": "{id_socd_pair_1_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #1 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_1", 0, 2]
+                },
+                {
+                  "label": "Pair #1 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_1_key_2", 0, 3]
+                }
+              ]
+            },
+            {
+              "label": "Pair #2 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_2_mode", 0, 4]
+            },
+            {
+              "showIf": "{id_socd_pair_2_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #2 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_1", 0, 5]
+                },
+                {
+                  "label": "Pair #2 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_2_key_2", 0, 6]
+                }
+              ]
+            },
+            {
+              "label": "Pair #3 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_3_mode", 0, 7]
+            },
+            {
+              "showIf": "{id_socd_pair_3_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #3 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_1", 0, 8]
+                },
+                {
+                  "label": "Pair #3 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_3_key_2", 0, 9]
+                }
+              ]
+            },
+            {
+              "label": "Pair #4 Mode",
+              "type": "dropdown",
+              "options": [
+                ["Disabled", 0],
+                ["Last Priority", 1],
+                ["Neutral", 2],
+                ["First Key Priority", 3],
+                ["Second Key Priority", 4]
+              ],
+              "content": ["id_socd_pair_4_mode", 0, 10]
+            },
+            {
+              "showIf": "{id_socd_pair_4_mode} != 0",
+              "content": [
+                {
+                  "label": "Pair #4 First Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_1", 0, 11]
+                },
+                {
+                  "label": "Pair #4 Second Key",
+                  "type": "keycode",
+                  "content": ["id_socd_pair_4_key_2", 0, 12]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Tap Dance",
+      "content": [
+        {
+          "label": "Tap Dance 0 - TD(0)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[0]", 9, 1, 0]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[0]", 9, 2, 0]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[0]", 9, 3, 0]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[0]", 9, 4, 0]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[0]", 9, 5, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 1 - TD(1)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[1]", 9, 1, 1]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[1]", 9, 2, 1]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[1]", 9, 3, 1]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[1]", 9, 4, 1]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[1]", 9, 5, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 2 - TD(2)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[2]", 9, 1, 2]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[2]", 9, 2, 2]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[2]", 9, 3, 2]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[2]", 9, 4, 2]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[2]", 9, 5, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 3 - TD(3)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[3]", 9, 1, 3]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[3]", 9, 2, 3]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[3]", 9, 3, 3]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[3]", 9, 4, 3]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[3]", 9, 5, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 4 - TD(4)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[4]", 9, 1, 4]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[4]", 9, 2, 4]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[4]", 9, 3, 4]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[4]", 9, 4, 4]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[4]", 9, 5, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 5 - TD(5)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[5]", 9, 1, 5]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[5]", 9, 2, 5]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[5]", 9, 3, 5]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[5]", 9, 4, 5]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[5]", 9, 5, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 6 - TD(6)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[6]", 9, 1, 6]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[6]", 9, 2, 6]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[6]", 9, 3, 6]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[6]", 9, 4, 6]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[6]", 9, 5, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 7 - TD(7)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[7]", 9, 1, 7]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[7]", 9, 2, 7]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[7]", 9, 3, 7]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[7]", 9, 4, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[7]", 9, 5, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 8 - TD(8)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[8]", 9, 5, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 9 - TD(9)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[9]", 9, 5, 9],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 10 - TD(10)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[10]", 9, 5, 10],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 11 - TD(11)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[11]", 9, 5, 11],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 12 - TD(12)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[12]", 9, 5, 12],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 13 - TD(13)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[13]", 9, 5, 13],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 14 - TD(14)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[14]", 9, 5, 14],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Tap Dance 15 - TD(15)",
+          "content": [
+            {
+              "label": "Single tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
+            },
+            {
+              "label": "Single hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
+            },
+            {
+              "label": "Double tap",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
+            },
+            {
+              "label": "Double hold",
+              "type": "keycode",
+              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tap_dance_term[15]", 9, 5, 15],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "label": "Combos",
+      "content": [
+        {
+          "label": "Combo 0",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[0][0]", 10, 1, 0, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[0][1]", 10, 1, 0, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[0][2]", 10, 1, 0, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[0][3]", 10, 1, 0, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[0]", 10, 2, 0]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[0]", 10, 3, 0],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 1",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[1][0]", 10, 1, 1, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[1][1]", 10, 1, 1, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[1][2]", 10, 1, 1, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[1][3]", 10, 1, 1, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[1]", 10, 2, 1]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[1]", 10, 3, 1],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 2",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[2][0]", 10, 1, 2, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[2][1]", 10, 1, 2, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[2][2]", 10, 1, 2, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[2][3]", 10, 1, 2, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[2]", 10, 2, 2]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[2]", 10, 3, 2],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 3",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[3][0]", 10, 1, 3, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[3][1]", 10, 1, 3, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[3][2]", 10, 1, 3, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[3][3]", 10, 1, 3, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[3]", 10, 2, 3]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[3]", 10, 3, 3],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 4",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[4][0]", 10, 1, 4, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[4][1]", 10, 1, 4, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[4][2]", 10, 1, 4, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[4][3]", 10, 1, 4, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[4]", 10, 2, 4]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[4]", 10, 3, 4],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 5",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[5][0]", 10, 1, 5, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[5][1]", 10, 1, 5, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[5][2]", 10, 1, 5, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[5][3]", 10, 1, 5, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[5]", 10, 2, 5]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[5]", 10, 3, 5],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 6",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[6][0]", 10, 1, 6, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[6][1]", 10, 1, 6, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[6][2]", 10, 1, 6, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[6][3]", 10, 1, 6, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[6]", 10, 2, 6]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[6]", 10, 3, 6],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 7",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[7][0]", 10, 1, 7, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[7][1]", 10, 1, 7, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[7][2]", 10, 1, 7, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[7][3]", 10, 1, 7, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[7]", 10, 2, 7]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[7]", 10, 3, 7],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 8",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[8][0]", 10, 1, 8, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[8][1]", 10, 1, 8, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[8][2]", 10, 1, 8, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[8][3]", 10, 1, 8, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[8]", 10, 2, 8]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[8]", 10, 3, 8],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo 9",
+          "content": [
+            {
+              "label": "Input key 1",
+              "type": "keycode",
+              "content": ["id_combo_key[9][0]", 10, 1, 9, 0]
+            },
+            {
+              "label": "Input key 2",
+              "type": "keycode",
+              "content": ["id_combo_key[9][1]", 10, 1, 9, 1]
+            },
+            {
+              "label": "Input key 3",
+              "type": "keycode",
+              "content": ["id_combo_key[9][2]", 10, 1, 9, 2]
+            },
+            {
+              "label": "Input key 4",
+              "type": "keycode",
+              "content": ["id_combo_key[9][3]", 10, 1, 9, 3]
+            },
+            {
+              "label": "Output keycode",
+              "type": "keycode",
+              "content": ["id_combo_output[9]", 10, 2, 9]
+            },
+            {
+              "label": "Combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_slot_term[9]", 10, 3, 9],
+              "options": [1, 1000]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "label": "QMK Settings",
+      "content": [
+        {
+          "label": "Grave Escape",
+          "content": [
+            {
+              "label": "Alt forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_alt_override", 8, 1]
+            },
+            {
+              "label": "Ctrl forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_ctrl_override", 8, 2]
+            },
+            {
+              "label": "GUI forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_gui_override", 8, 3]
+            },
+            {
+              "label": "Shift forces Escape",
+              "type": "toggle",
+              "content": ["id_grave_esc_shift_override", 8, 4]
+            }
+          ]
+        },
+        {
+          "label": "Tap-Hold and Mod-Tap",
+          "content": [
+            {
+              "label": "Permissive hold",
+              "type": "toggle",
+              "content": ["id_permissive_hold", 8, 5]
+            },
+            {
+              "label": "Retro tapping",
+              "type": "toggle",
+              "content": ["id_retro_tapping", 8, 6]
+            },
+            {
+              "label": "Hold on other key press",
+              "type": "toggle",
+              "content": ["id_hold_on_other_key_press", 8, 7]
+            },
+            {
+              "label": "Tapping term (ms)",
+              "type": "range",
+              "content": ["id_tapping_term", 8, 8],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Quick-tap term (ms)",
+              "type": "range",
+              "content": ["id_quick_tap_term", 8, 9],
+              "options": [0, 1000]
+            },
+            {
+              "label": "Reset all Tap Dance slots",
+              "type": "button",
+              "content": ["id_tap_dance_reset", 9, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "Auto Shift",
+          "content": [
+            {
+              "label": "Enable Auto Shift",
+              "type": "toggle",
+              "content": ["id_auto_shift_enabled", 8, 10]
+            },
+            {
+              "label": "Include modifiers",
+              "type": "toggle",
+              "content": ["id_auto_shift_modifiers", 8, 11]
+            },
+            {
+              "label": "Include alpha keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_alpha", 8, 12]
+            },
+            {
+              "label": "Include number keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_numeric", 8, 13]
+            },
+            {
+              "label": "Include symbol keys",
+              "type": "toggle",
+              "content": ["id_auto_shift_symbols", 8, 14]
+            },
+            {
+              "label": "Include Tab",
+              "type": "toggle",
+              "content": ["id_auto_shift_tab", 8, 15]
+            },
+            {
+              "label": "Enable key repeat",
+              "type": "toggle",
+              "content": ["id_auto_shift_repeat", 8, 16]
+            },
+            {
+              "label": "Disable automatic repeat after timeout",
+              "type": "toggle",
+              "content": ["id_auto_shift_no_repeat", 8, 17]
+            },
+            {
+              "label": "Auto Shift timeout (ms)",
+              "type": "range",
+              "content": ["id_auto_shift_timeout", 8, 18],
+              "options": [1, 1000]
+            }
+          ]
+        },
+        {
+          "label": "Combo Behavior",
+          "content": [
+            {
+              "label": "Enable combos",
+              "type": "toggle",
+              "content": ["id_combo_enabled", 8, 19]
+            },
+            {
+              "label": "Combos must be held",
+              "type": "toggle",
+              "content": ["id_combo_must_hold", 8, 20]
+            },
+            {
+              "label": "Combos must be tapped",
+              "type": "toggle",
+              "content": ["id_combo_must_tap", 8, 21]
+            },
+            {
+              "label": "Keys must be pressed in order",
+              "type": "toggle",
+              "content": ["id_combo_press_in_order", 8, 22]
+            },
+            {
+              "label": "Default combo term (ms)",
+              "type": "range",
+              "content": ["id_combo_term", 8, 23],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Combo hold term (ms)",
+              "type": "range",
+              "content": ["id_combo_hold_term", 8, 24],
+              "options": [1, 1000]
+            },
+            {
+              "label": "Reset all Combo slots",
+              "type": "button",
+              "content": ["id_combo_reset", 10, 0],
+              "options": [0]
+            }
+          ]
+        },
+        {
+          "label": "One-Shot Keys",
+          "content": [
+            {
+              "label": "Enable one-shot keys",
+              "type": "toggle",
+              "content": ["id_magic_oneshot_enabled", 7, 12]
+            }
+          ]
+        },
+        {
+          "label": "Mouse Keys",
+          "content": [
+            {
+              "label": "Initial movement delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_delay", 8, 25],
+              "options": [0, 255]
+            },
+            {
+              "label": "Movement interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_interval", 8, 26],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum cursor speed",
+              "type": "range",
+              "content": ["id_mouse_max_speed", 8, 27],
+              "options": [1, 255]
+            },
+            {
+              "label": "Cursor acceleration time",
+              "type": "range",
+              "content": ["id_mouse_time_to_max", 8, 28],
+              "options": [1, 255]
+            },
+            {
+              "label": "Initial wheel delay (10 ms units)",
+              "type": "range",
+              "content": ["id_mouse_wheel_delay", 8, 29],
+              "options": [0, 255]
+            },
+            {
+              "label": "Wheel interval (ms)",
+              "type": "range",
+              "content": ["id_mouse_wheel_interval", 8, 30],
+              "options": [1, 255]
+            },
+            {
+              "label": "Maximum wheel speed",
+              "type": "range",
+              "content": ["id_mouse_wheel_max_speed", 8, 31],
+              "options": [1, 255]
+            },
+            {
+              "label": "Wheel acceleration time",
+              "type": "range",
+              "content": ["id_mouse_wheel_time_to_max", 8, 32],
+              "options": [1, 255]
+            }
+          ]
+        },
+        {
+          "label": "Miscellaneous",
+          "content": [
+            {
+              "label": "Enable NKRO",
+              "type": "toggle",
+              "content": ["id_magic_nkro", 7, 1]
+            },
+            {
+              "label": "Lock GUI key",
+              "type": "toggle",
+              "content": ["id_magic_no_gui", 7, 2]
+            },
+            {
+              "label": "Caps Lock acts as Ctrl",
+              "type": "toggle",
+              "content": ["id_magic_capslock_to_control", 7, 3]
+            },
+            {
+              "label": "Swap Ctrl and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_control_capslock", 7, 4]
+            },
+            {
+              "label": "Swap Escape and Caps Lock",
+              "type": "toggle",
+              "content": ["id_magic_swap_escape_capslock", 7, 5]
+            },
+            {
+              "label": "Swap left Alt and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lalt_lgui", 7, 6]
+            },
+            {
+              "label": "Swap right Alt and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_ralt_rgui", 7, 7]
+            },
+            {
+              "label": "Swap left Ctrl and left GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_lctl_lgui", 7, 8]
+            },
+            {
+              "label": "Swap right Ctrl and right GUI",
+              "type": "toggle",
+              "content": ["id_magic_swap_rctl_rgui", 7, 9]
+            },
+            {
+              "label": "Swap Grave and Escape",
+              "type": "toggle",
+              "content": ["id_magic_swap_grave_esc", 7, 10]
+            },
+            {
+              "label": "Swap Backslash and Backspace",
+              "type": "toggle",
+              "content": ["id_magic_swap_backslash_backspace", 7, 11]
+            }
+          ]
+        }
+      ],
+      "showIf": "{id_firmware_version} >= 1"
+    },
+    {
+      "showIf": "{id_firmware_version} >= 1",
+      "label": "Board System",
+      "content": [
+        {
+          "label": "Board Maintenance",
+          "content": [
+            {
+              "showIf": "{id_firmware_version} >= 3",
+              "content": [
+                {
+                  "label": "Firmware Version",
+                  "type": "label",
+                  "content": ["id_firmware_version_text", 0, 15]
+                },
+                {
+                  "label": "Firmware Build",
+                  "type": "label",
+                  "content": ["id_firmware_build_text", 0, 16]
+                }
+              ]
+            },
+            {
+              "label": "Flash Mode",
+              "type": "button",
+              "options": [0],
+              "content": ["id_flash_mode", 0, 13]
+            },
+            {
+              "label": "Factory reset (erases all settings and restarts)",
+              "type": "button",
+              "options": [0],
+              "content": ["id_factory_reset", 0, 14]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "layouts": {
     "labels": [["Layout", "BAE/ANSI", "ISO", "Simon"]],
     "keymap": [

--- a/v3/cipulot/lily/lily.json
+++ b/v3/cipulot/lily/lily.json
@@ -1,7 +1,11 @@
 {
-  "name": "Chroma",
+  "name": "Lily",
   "vendorId": "0x6369",
-  "productId": "0x6BBF",
+  "productId": "0x0026",
+  "matrix": {
+    "rows": 5,
+    "cols": 14
+  },
   "customKeycodes": [
     {
       "name": "TD(0)",
@@ -42,46 +46,6 @@
       "name": "TD(7)",
       "title": "Tap Dance slot 7",
       "shortName": "TD\n7"
-    },
-    {
-      "name": "TD(8)",
-      "title": "Tap Dance slot 8",
-      "shortName": "TD\n8"
-    },
-    {
-      "name": "TD(9)",
-      "title": "Tap Dance slot 9",
-      "shortName": "TD\n9"
-    },
-    {
-      "name": "TD(10)",
-      "title": "Tap Dance slot 10",
-      "shortName": "TD\n10"
-    },
-    {
-      "name": "TD(11)",
-      "title": "Tap Dance slot 11",
-      "shortName": "TD\n11"
-    },
-    {
-      "name": "TD(12)",
-      "title": "Tap Dance slot 12",
-      "shortName": "TD\n12"
-    },
-    {
-      "name": "TD(13)",
-      "title": "Tap Dance slot 13",
-      "shortName": "TD\n13"
-    },
-    {
-      "name": "TD(14)",
-      "title": "Tap Dance slot 14",
-      "shortName": "TD\n14"
-    },
-    {
-      "name": "TD(15)",
-      "title": "Tap Dance slot 15",
-      "shortName": "TD\n15"
     },
     {
       "name": "OS_LCTL",
@@ -154,13 +118,182 @@
       "shortName": "KEY\nLOCK"
     }
   ],
-  "matrix": {
-    "rows": 5,
-    "cols": 15
-  },
   "menus": [
     {
-      "showIf": "{id_firmware_version} >= 1",
+      "label": "Indicators",
+      "content": [
+        {
+          "label": "Left indicator",
+          "content": [
+            {
+              "label": "Enable Left Indicator",
+              "type": "toggle",
+              "content": ["id_ind1_enabled", 0, 1]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "content": [
+                {
+                  "label": "Brightness",
+                  "type": "range",
+                  "options": [0, 255],
+                  "content": ["id_ind1_brightness", 0, 2]
+                },
+                {
+                  "label": "Color",
+                  "type": "color",
+                  "content": ["id_ind1_color", 0, 3]
+                },
+                {
+                  "label": "Function 1",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind1_func1", 0, 4]
+                },
+                {
+                  "label": "Function 2",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind1_func2", 0, 5]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Central indicator",
+          "content": [
+            {
+              "label": "Enable Central Indicator",
+              "type": "toggle",
+              "content": ["id_ind2_enabled", 0, 6]
+            },
+            {
+              "showIf": "{id_ind2_enabled} == 1",
+              "content": [
+                {
+                  "label": "Brightness",
+                  "type": "range",
+                  "options": [0, 255],
+                  "content": ["id_ind2_brightness", 0, 7]
+                },
+                {
+                  "label": "Color",
+                  "type": "color",
+                  "content": ["id_ind2_color", 0, 8]
+                },
+                {
+                  "label": "Function 1",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind2_func1", 0, 9]
+                },
+                {
+                  "label": "Function 2",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind2_func2", 0, 10]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Right indicator",
+          "content": [
+            {
+              "label": "Enable Right Indicator",
+              "type": "toggle",
+              "content": ["id_ind3_enabled", 0, 11]
+            },
+            {
+              "showIf": "{id_ind3_enabled} == 1",
+              "content": [
+                {
+                  "label": "Brightness",
+                  "type": "range",
+                  "options": [0, 255],
+                  "content": ["id_ind3_brightness", 0, 12]
+                },
+                {
+                  "label": "Color",
+                  "type": "color",
+                  "content": ["id_ind3_color", 0, 13]
+                },
+                {
+                  "label": "Function 1",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind3_func1", 0, 14]
+                },
+                {
+                  "label": "Function 2",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind3_func2", 0, 15]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "showIf": "{id_firmware_version} >= 2",
       "label": "Advanced Features",
       "content": [
         {
@@ -176,7 +309,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_1_mode", 0, 1]
+              "content": ["id_socd_pair_1_mode", 0, 16]
             },
             {
               "showIf": "{id_socd_pair_1_mode} != 0",
@@ -184,12 +317,12 @@
                 {
                   "label": "Pair #1 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_1", 0, 2]
+                  "content": ["id_socd_pair_1_key_1", 0, 17]
                 },
                 {
                   "label": "Pair #1 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_1_key_2", 0, 3]
+                  "content": ["id_socd_pair_1_key_2", 0, 18]
                 }
               ]
             },
@@ -203,7 +336,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_2_mode", 0, 4]
+              "content": ["id_socd_pair_2_mode", 0, 19]
             },
             {
               "showIf": "{id_socd_pair_2_mode} != 0",
@@ -211,12 +344,12 @@
                 {
                   "label": "Pair #2 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_1", 0, 5]
+                  "content": ["id_socd_pair_2_key_1", 0, 20]
                 },
                 {
                   "label": "Pair #2 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_2_key_2", 0, 6]
+                  "content": ["id_socd_pair_2_key_2", 0, 21]
                 }
               ]
             },
@@ -230,7 +363,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_3_mode", 0, 7]
+              "content": ["id_socd_pair_3_mode", 0, 22]
             },
             {
               "showIf": "{id_socd_pair_3_mode} != 0",
@@ -238,12 +371,12 @@
                 {
                   "label": "Pair #3 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_1", 0, 8]
+                  "content": ["id_socd_pair_3_key_1", 0, 23]
                 },
                 {
                   "label": "Pair #3 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_3_key_2", 0, 9]
+                  "content": ["id_socd_pair_3_key_2", 0, 24]
                 }
               ]
             },
@@ -257,7 +390,7 @@
                 ["First Key Priority", 3],
                 ["Second Key Priority", 4]
               ],
-              "content": ["id_socd_pair_4_mode", 0, 10]
+              "content": ["id_socd_pair_4_mode", 0, 25]
             },
             {
               "showIf": "{id_socd_pair_4_mode} != 0",
@@ -265,12 +398,12 @@
                 {
                   "label": "Pair #4 First Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_1", 0, 11]
+                  "content": ["id_socd_pair_4_key_1", 0, 26]
                 },
                 {
                   "label": "Pair #4 Second Key",
                   "type": "keycode",
-                  "content": ["id_socd_pair_4_key_2", 0, 12]
+                  "content": ["id_socd_pair_4_key_2", 0, 27]
                 }
               ]
             }
@@ -528,257 +661,9 @@
               "options": [1, 1000]
             }
           ]
-        },
-        {
-          "label": "Tap Dance 8 - TD(8)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[8]", 9, 1, 8]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[8]", 9, 2, 8]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[8]", 9, 3, 8]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[8]", 9, 4, 8]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[8]", 9, 5, 8],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 9 - TD(9)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[9]", 9, 1, 9]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[9]", 9, 2, 9]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[9]", 9, 3, 9]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[9]", 9, 4, 9]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[9]", 9, 5, 9],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 10 - TD(10)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[10]", 9, 1, 10]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[10]", 9, 2, 10]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[10]", 9, 3, 10]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[10]", 9, 4, 10]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[10]", 9, 5, 10],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 11 - TD(11)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[11]", 9, 1, 11]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[11]", 9, 2, 11]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[11]", 9, 3, 11]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[11]", 9, 4, 11]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[11]", 9, 5, 11],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 12 - TD(12)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[12]", 9, 1, 12]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[12]", 9, 2, 12]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[12]", 9, 3, 12]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[12]", 9, 4, 12]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[12]", 9, 5, 12],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 13 - TD(13)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[13]", 9, 1, 13]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[13]", 9, 2, 13]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[13]", 9, 3, 13]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[13]", 9, 4, 13]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[13]", 9, 5, 13],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 14 - TD(14)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[14]", 9, 1, 14]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[14]", 9, 2, 14]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[14]", 9, 3, 14]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[14]", 9, 4, 14]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[14]", 9, 5, 14],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
-          "label": "Tap Dance 15 - TD(15)",
-          "content": [
-            {
-              "label": "Single tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_tap[15]", 9, 1, 15]
-            },
-            {
-              "label": "Single hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_single_hold[15]", 9, 2, 15]
-            },
-            {
-              "label": "Double tap",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_tap[15]", 9, 3, 15]
-            },
-            {
-              "label": "Double hold",
-              "type": "keycode",
-              "content": ["id_tap_dance_double_hold[15]", 9, 4, 15]
-            },
-            {
-              "label": "Tapping term (ms)",
-              "type": "range",
-              "content": ["id_tap_dance_term[15]", 9, 5, 15],
-              "options": [1, 1000]
-            }
-          ]
         }
       ],
-      "showIf": "{id_firmware_version} >= 1"
+      "showIf": "{id_firmware_version} >= 2"
     },
     {
       "label": "Combos",
@@ -1144,7 +1029,7 @@
           ]
         }
       ],
-      "showIf": "{id_firmware_version} >= 1"
+      "showIf": "{id_firmware_version} >= 2"
     },
     {
       "label": "QMK Settings",
@@ -1213,57 +1098,6 @@
           ]
         },
         {
-          "label": "Auto Shift",
-          "content": [
-            {
-              "label": "Enable Auto Shift",
-              "type": "toggle",
-              "content": ["id_auto_shift_enabled", 8, 10]
-            },
-            {
-              "label": "Include modifiers",
-              "type": "toggle",
-              "content": ["id_auto_shift_modifiers", 8, 11]
-            },
-            {
-              "label": "Include alpha keys",
-              "type": "toggle",
-              "content": ["id_auto_shift_alpha", 8, 12]
-            },
-            {
-              "label": "Include number keys",
-              "type": "toggle",
-              "content": ["id_auto_shift_numeric", 8, 13]
-            },
-            {
-              "label": "Include symbol keys",
-              "type": "toggle",
-              "content": ["id_auto_shift_symbols", 8, 14]
-            },
-            {
-              "label": "Include Tab",
-              "type": "toggle",
-              "content": ["id_auto_shift_tab", 8, 15]
-            },
-            {
-              "label": "Enable key repeat",
-              "type": "toggle",
-              "content": ["id_auto_shift_repeat", 8, 16]
-            },
-            {
-              "label": "Disable automatic repeat after timeout",
-              "type": "toggle",
-              "content": ["id_auto_shift_no_repeat", 8, 17]
-            },
-            {
-              "label": "Auto Shift timeout (ms)",
-              "type": "range",
-              "content": ["id_auto_shift_timeout", 8, 18],
-              "options": [1, 1000]
-            }
-          ]
-        },
-        {
           "label": "Combo Behavior",
           "content": [
             {
@@ -1313,59 +1147,6 @@
               "label": "Enable one-shot keys",
               "type": "toggle",
               "content": ["id_magic_oneshot_enabled", 7, 12]
-            }
-          ]
-        },
-        {
-          "label": "Mouse Keys",
-          "content": [
-            {
-              "label": "Initial movement delay (10 ms units)",
-              "type": "range",
-              "content": ["id_mouse_delay", 8, 25],
-              "options": [0, 255]
-            },
-            {
-              "label": "Movement interval (ms)",
-              "type": "range",
-              "content": ["id_mouse_interval", 8, 26],
-              "options": [1, 255]
-            },
-            {
-              "label": "Maximum cursor speed",
-              "type": "range",
-              "content": ["id_mouse_max_speed", 8, 27],
-              "options": [1, 255]
-            },
-            {
-              "label": "Cursor acceleration time",
-              "type": "range",
-              "content": ["id_mouse_time_to_max", 8, 28],
-              "options": [1, 255]
-            },
-            {
-              "label": "Initial wheel delay (10 ms units)",
-              "type": "range",
-              "content": ["id_mouse_wheel_delay", 8, 29],
-              "options": [0, 255]
-            },
-            {
-              "label": "Wheel interval (ms)",
-              "type": "range",
-              "content": ["id_mouse_wheel_interval", 8, 30],
-              "options": [1, 255]
-            },
-            {
-              "label": "Maximum wheel speed",
-              "type": "range",
-              "content": ["id_mouse_wheel_max_speed", 8, 31],
-              "options": [1, 255]
-            },
-            {
-              "label": "Wheel acceleration time",
-              "type": "range",
-              "content": ["id_mouse_wheel_time_to_max", 8, 32],
-              "options": [1, 255]
             }
           ]
         },
@@ -1430,41 +1211,40 @@
           ]
         }
       ],
-      "showIf": "{id_firmware_version} >= 1"
+      "showIf": "{id_firmware_version} >= 2"
     },
     {
-      "showIf": "{id_firmware_version} >= 1",
+      "showIf": "{id_firmware_version} >= 2",
       "label": "Board System",
       "content": [
         {
           "label": "Board Maintenance",
           "content": [
             {
-              "showIf": "{id_firmware_version} >= 3",
-              "content": [
-                {
-                  "label": "Firmware Version",
-                  "type": "label",
-                  "content": ["id_firmware_version_text", 0, 15]
-                },
-                {
-                  "label": "Firmware Build",
-                  "type": "label",
-                  "content": ["id_firmware_build_text", 0, 16]
-                }
-              ]
+              "showIf": "{id_firmware_version} >= 2",
+              "label": "Firmware Version",
+              "type": "label",
+              "content": ["id_firmware_version_text", 0, 30]
+            },
+            {
+              "showIf": "{id_firmware_version} >= 2",
+              "label": "Firmware Build",
+              "type": "label",
+              "content": ["id_firmware_build_text", 0, 31]
             },
             {
               "label": "Flash Mode",
               "type": "button",
               "options": [0],
-              "content": ["id_flash_mode", 0, 13]
+              "content": ["id_flash_mode", 0, 28],
+              "showIf": "{id_firmware_version} >= 2"
             },
             {
               "label": "Factory reset (erases all settings and restarts)",
               "type": "button",
               "options": [0],
-              "content": ["id_factory_reset", 0, 14]
+              "content": ["id_factory_reset", 0, 29],
+              "showIf": "{id_firmware_version} >= 2"
             }
           ]
         }
@@ -1472,18 +1252,20 @@
     }
   ],
   "layouts": {
-    "labels": [
-      "Split Backspace",
-      "Split Left Shift",
-      "Split Right Shift",
-      "ISO",
-      ["Bottom Row", "7U WK", "7U WKL"]
-    ],
+    "labels": ["Unified Backspace", "Split Spacebar"],
     "keymap": [
       [
         {
-          "x": 2.5,
-          "c": "#aaaaaa"
+          "x": 13,
+          "c": "#aaaaaa",
+          "w": 2
+        },
+        "0,13\n\n\n0,1"
+      ],
+      [
+        {
+          "y": 0.25,
+          "c": "#777777"
         },
         "0,0",
         {
@@ -1501,24 +1283,14 @@
         "0,10",
         "0,11",
         "0,12",
-        {
-          "c": "#aaaaaa",
-          "w": 2
-        },
-        "0,14\n\n\n0,0",
-        {
-          "x": 1.5,
-          "c": "#cccccc"
-        },
-        "0,13\n\n\n0,1",
+        "0,13\n\n\n0,0",
         {
           "c": "#aaaaaa"
         },
-        "0,14\n\n\n0,1"
+        "2,12\n\n\n0,0"
       ],
       [
         {
-          "x": 2.5,
           "w": 1.5
         },
         "1,0",
@@ -1538,23 +1310,13 @@
         "1,11",
         "1,12",
         {
-          "c": "#aaaaaa",
           "w": 1.5
         },
-        "1,13\n\n\n3,0",
-        {
-          "x": 2.25,
-          "w": 1.25,
-          "h": 2,
-          "w2": 1.5,
-          "h2": 1,
-          "x2": -0.25
-        },
-        "2,13\n\n\n3,1"
+        "1,13"
       ],
       [
         {
-          "x": 2.5,
+          "c": "#aaaaaa",
           "w": 1.75
         },
         "2,0",
@@ -1573,28 +1335,17 @@
         "2,10",
         "2,11",
         {
-          "c": "#aaaaaa",
+          "c": "#777777",
           "w": 2.25
         },
-        "2,13\n\n\n3,0",
-        {
-          "x": 1.25,
-          "c": "#cccccc"
-        },
-        "2,12\n\n\n3,1"
+        "2,13"
       ],
       [
         {
           "c": "#aaaaaa",
-          "w": 1.25
-        },
-        "3,0\n\n\n1,1",
-        "3,1\n\n\n1,1",
-        {
-          "x": 0.25,
           "w": 2.25
         },
-        "3,0\n\n\n1,0",
+        "3,0",
         {
           "c": "#cccccc"
         },
@@ -1610,76 +1361,45 @@
         "3,11",
         {
           "c": "#aaaaaa",
-          "w": 2.75
-        },
-        "3,12\n\n\n2,0",
-        {
-          "x": 0.75,
           "w": 1.75
         },
-        "3,12\n\n\n2,1",
-        "3,13\n\n\n2,1"
+        "3,12",
+        "3,13"
       ],
       [
         {
-          "x": 2.5,
-          "w": 1.5
+          "x": 1.5
         },
-        "4,0\n\n\n4,0",
-        "4,1\n\n\n4,0",
+        "4,1",
         {
           "w": 1.5
         },
-        "4,2\n\n\n4,0",
+        "4,2",
         {
           "c": "#cccccc",
           "w": 7
         },
-        "4,7\n\n\n4,0",
+        "4,7\n\n\n1,0",
         {
           "c": "#aaaaaa",
           "w": 1.5
         },
-        "4,11\n\n\n4,0",
-        "4,12\n\n\n4,0",
-        {
-          "w": 1.5
-        },
-        "4,13\n\n\n4,0"
+        "4,11",
+        "4,12"
       ],
       [
         {
           "y": 0.25,
-          "x": 2.5,
-          "w": 1.5
-        },
-        "4,0\n\n\n4,1",
-        {
-          "d": true
-        },
-        "4,1\n\n\n4,1",
-        {
-          "w": 1.5
-        },
-        "4,2\n\n\n4,1",
-        {
+          "x": 4,
           "c": "#cccccc",
-          "w": 7
+          "w": 3
         },
-        "4,7\n\n\n4,1",
+        "4,5\n\n\n1,1",
+        "4,7\n\n\n1,1",
         {
-          "c": "#aaaaaa",
-          "w": 1.5
+          "w": 3
         },
-        "4,11\n\n\n4,1",
-        {
-          "d": true
-        },
-        "4,12\n\n\n4,1",
-        {
-          "w": 1.5
-        },
-        "4,13\n\n\n4,1"
+        "4,9\n\n\n1,1"
       ]
     ]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have used explicit QMK lighting keycode modules instead of the legacy `qmk_lighting` module.
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
