### PR TITLE
Yet another one

### DIFF
--- a/v3/cipulot/ec_23u/ec_23u.json
+++ b/v3/cipulot/ec_23u/ec_23u.json
@@ -367,6 +367,42 @@
   "menus": [
     "qmk_rgblight",
     {
+      "showIf": "{id_firmware_version} >= 6",
+      "label": "Indicators",
+      "content": [
+        {
+          "label": "Num Lock LED",
+          "content": [
+            {
+              "label": "Enable Num Lock LED",
+              "type": "toggle",
+              "content": ["id_ind1_enabled", 0, 28]
+            },
+            {
+              "showIf": "{id_ind1_enabled} == 1",
+              "content": [
+                {
+                  "label": "Function",
+                  "type": "dropdown",
+                  "options": [
+                    "None",
+                    "Caps Lock",
+                    "Num Lock",
+                    "Scroll Lock",
+                    "Layer 0",
+                    "Layer 1",
+                    "Layer 2",
+                    "Layer 3"
+                  ],
+                  "content": ["id_ind1_func", 0, 29]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Switch Configuration",
       "content": [
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## VIA Keymap Pull Request

<!--- Add your VIA keymap PR here -->
<!--- PR to https://github.com/the-via/qmk_userspace_via/pulls -->

<!--- All keyboards merge into QMK including and after 0.26.0 must have this VIA keymap PR -->

<!--- IF THERE IS NO LINK TO SHOW VIA KEYMAP PR, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [ ] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [ ] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [ ] I have used explicit QMK lighting keycode modules instead of the legacy `qmk_lighting` module.
- [ ] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [ ] I have tested this keyboard definition using VIA's "Design" tab.
- [ ] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [ ] The Vendor ID is not `0xFEED`
