### PR TITLE
Add lighting menu for kbd67mkiirgb v3

### DIFF
--- a/v3/kbdfans/kbd67mkii/kbd67mkiirgbv3.json
+++ b/v3/kbdfans/kbd67mkii/kbd67mkiirgbv3.json
@@ -6,6 +6,72 @@
     "rows": 5,
     "cols": 15
   },
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "RGB Matrix",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                ["All Off", 0],
+                ["Solid Color", 1],
+                ["Alphas Mods", 2],
+                ["Gradient Left/Right", 3],
+                ["Breathing", 4],
+                ["Band Val.", 5],
+                ["Pinwheel Val.", 6],
+                ["Spiral Val.", 7],
+                ["Cycle All", 8],
+                ["Cycle Left/Right", 9],
+                ["Cycle Up/Down", 10],
+                ["Rainbow Moving Chevron", 11],
+                ["Cycle Out/In", 12],
+                ["Cycle Out/In Dual", 13],
+                ["Cycle Pinwheel", 14],
+                ["Cycle Spiral", 15],
+                ["Dual Beacon", 16],
+                ["Rainbow Beacon", 17],
+                ["Rainbow Pinwheels", 18],
+                ["Raindrops", 19],
+                ["Jellybean Raindrops", 20],
+                ["Hue Breathing", 21],
+                ["Hue Pendulum", 22],
+                ["Hue Wave", 23],
+                ["Pixel Rain", 24],
+                ["Pixel Flow", 25],
+                ["Pixel Fractal", 26],
+                ["Typing Heatmap", 27]
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "keycodes": ["qmk_rgb_matrix_keycodes"],
   "layouts": {
     "keymap": [


### PR DESCRIPTION
## Description

Adds the missing menus block to v3/kbdfans/kbd67mkii/kbd67mkiirgbv3.json for lighting menu support.

Current V3 definitions had no menus for lighting since the last time an issue was made for it (https://github.com/the-via/keyboards/issues/1131) was when VIA's lighting UI did not support per-key RGB/RGB Matrix at that time and was understandably closed.

The reason I went with a custom menu instead of `"menus": ["qmk_rgb_matrix"]` was due to the QMK source firmware only compiling [26 of the RGB Matrix animations](https://github.com/qmk/qmk_firmware/blob/master/keyboards/kbdfans/kbd67/mkiirgb/v3/keyboard.json). The uncompiled effects shift every later mode down and the built-in menu assumes the full effect order (at least in my testing). This would cause the dropdown to mislabel entries and address nonexistent modes on this board and Custom UI specification seems to support this.

Do note that I only specify kbd67mkiirgb v3 since it's the only PCB I own, I'm unsure how other versions would react to the changes.

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/13714

## VIA Keymap Pull Request

https://github.com/qmk/qmk_firmware/pull/8085
(PR was made for v1/v2 but in the current userspace repository, this seems to apply to all kbd67mkiirgb versions.)

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap is **MERGED** in VIA userspace master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have used explicit QMK lighting keycode modules instead of the legacy `qmk_lighting` module.
- [x] I have formatted the JSON file to have consistent formatting with the rest of the repository.
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
